### PR TITLE
Add hand management and mentsu detection

### DIFF
--- a/src/core/hand.ml
+++ b/src/core/hand.ml
@@ -1,0 +1,64 @@
+(** 手牌 *)
+type t = {
+  tiles : Tile.tile list;      (** 手牌（ツモ牌含む、最大14枚） *)
+  tsumo : Tile.tile option;    (** 最後にツモった牌 *)
+}
+
+(** 空の手牌 *)
+let empty = { tiles = []; tsumo = None }
+
+(** 手牌を作成 *)
+let make tiles = {
+  tiles = List.sort Tile.compare tiles;
+  tsumo = None;
+}
+
+(** 手牌の枚数 *)
+let count hand = List.length hand.tiles
+
+(** 牌を追加（ツモ） *)
+let tsumo tile hand =
+  if count hand >= 14 then
+    Error "手牌が14枚を超えます"
+  else
+    Ok { tiles = List.sort Tile.compare (tile :: hand.tiles); tsumo = Some tile }
+
+(** 牌を捨てる *)
+let discard tile hand =
+  match Mentsu.remove_one tile hand.tiles with
+  | Some remaining -> Ok { tiles = remaining; tsumo = None }
+  | None -> Error "指定された牌が手牌にありません"
+
+(** 手牌をソート *)
+let sort hand =
+  { hand with tiles = List.sort Tile.compare hand.tiles }
+
+(** 手牌を文字列に変換 *)
+let to_string hand =
+  hand.tiles
+  |> List.map Tile.to_string
+  |> String.concat " "
+
+(** 和了判定 *)
+let is_agari hand =
+  Mentsu.is_agari hand.tiles
+
+(** 和了パターンを取得 *)
+let agari_patterns hand =
+  Mentsu.find_agari_patterns hand.tiles
+
+(** テンパイ判定: 何か1枚加えれば和了になるか *)
+let tenpai_tiles hand =
+  if count hand <> 13 then []
+  else
+    let candidates =
+      let suits = [Tile.Manzu; Tile.Pinzu; Tile.Souzu] in
+      let numbers = [1; 2; 3; 4; 5; 6; 7; 8; 9] in
+      let jihais = [Tile.Ton; Tile.Nan; Tile.Sha; Tile.Pei; Tile.Haku; Tile.Hatsu; Tile.Chun] in
+      let suhai = List.concat_map (fun s -> List.map (fun n -> Tile.Suhai (s, n)) numbers) suits in
+      let jihai = List.map (fun j -> Tile.Jihai j) jihais in
+      suhai @ jihai
+    in
+    List.filter (fun t ->
+      Mentsu.is_agari (List.sort Tile.compare (t :: hand.tiles))
+    ) candidates

--- a/src/core/mentsu.ml
+++ b/src/core/mentsu.ml
@@ -1,0 +1,103 @@
+(** 面子の種類 *)
+type mentsu =
+  | Shuntsu of Tile.tile * Tile.tile * Tile.tile  (** 順子: 連続する3枚の数牌 *)
+  | Koutsu of Tile.tile                           (** 刻子: 同じ牌3枚 *)
+  | Kantsu of Tile.tile                           (** 槓子: 同じ牌4枚 *)
+
+(** 雀頭 *)
+type jantai = Tile.tile
+
+(** 和了形: 4面子1雀頭 *)
+type agari_pattern = {
+  mentsu_list : mentsu list;
+  jantai : jantai;
+}
+
+(** 数牌の次の牌を返す *)
+let next_suhai suit n =
+  if n < 9 then Some (Tile.Suhai (suit, n + 1)) else None
+
+(** 順子になりうるか判定 *)
+let is_shuntsu t1 t2 t3 =
+  match (t1, t2, t3) with
+  | Tile.Suhai (s1, n1), Tile.Suhai (s2, n2), Tile.Suhai (s3, n3) ->
+    s1 = s2 && s2 = s3 && n2 = n1 + 1 && n3 = n1 + 2
+  | _ -> false
+
+(** 刻子になりうるか判定 *)
+let is_koutsu t1 t2 t3 =
+  Tile.compare t1 t2 = 0 && Tile.compare t2 t3 = 0
+
+(** リストから指定の牌を1枚取り除く *)
+let remove_one tile tiles =
+  let rec aux acc = function
+    | [] -> None
+    | x :: rest ->
+      if Tile.compare x tile = 0 then Some (List.rev acc @ rest)
+      else aux (x :: acc) rest
+  in
+  aux [] tiles
+
+(** ソート済みの牌リストから全ての和了パターンを探索する *)
+let find_agari_patterns (tiles : Tile.tile list) : agari_pattern list =
+  let sorted = List.sort Tile.compare tiles in
+
+  (* 面子を再帰的に抽出する *)
+  let rec extract_mentsu (remaining : Tile.tile list) (acc_mentsu : mentsu list) : (mentsu list * Tile.tile list) list =
+    match remaining with
+    | [] -> [(List.rev acc_mentsu, [])]
+    | t1 :: rest ->
+      let results = ref [] in
+
+      (* 刻子を試す *)
+      (match rest with
+       | t2 :: t3 :: rest2 when is_koutsu t1 t2 t3 ->
+         let sub = extract_mentsu rest2 (Koutsu t1 :: acc_mentsu) in
+         results := sub @ !results
+       | _ -> ());
+
+      (* 順子を試す *)
+      (match t1 with
+       | Tile.Suhai (suit, n) ->
+         let t2 = Tile.Suhai (suit, n + 1) in
+         let t3 = Tile.Suhai (suit, n + 2) in
+         (match remove_one t2 rest with
+          | Some rest_after_t2 ->
+            (match remove_one t3 rest_after_t2 with
+             | Some rest_after_t3 ->
+               let sub = extract_mentsu rest_after_t3 (Shuntsu (t1, t2, t3) :: acc_mentsu) in
+               results := sub @ !results
+             | None -> ())
+          | None -> ())
+       | _ -> ());
+
+      !results
+  in
+
+  (* 雀頭候補を列挙して、残りから4面子を探す *)
+  let rec try_jantai (tiles : Tile.tile list) : agari_pattern list =
+    match tiles with
+    | [] -> []
+    | t1 :: rest ->
+      let patterns =
+        match remove_one t1 rest with
+        | Some rest_without_pair ->
+          let mentsu_results = extract_mentsu (List.sort Tile.compare rest_without_pair) [] in
+          List.filter_map (fun (ms, leftover) ->
+            if leftover = [] && List.length ms = 4 then
+              Some { mentsu_list = ms; jantai = t1 }
+            else
+              None
+          ) mentsu_results
+        | None -> []
+      in
+      (* 同じ牌の雀頭は一度だけ試す *)
+      let skip_same = List.filter (fun t -> Tile.compare t t1 <> 0) rest in
+      patterns @ try_jantai skip_same
+  in
+
+  try_jantai sorted
+
+(** 和了判定: 14枚の手牌が4面子1雀頭に分解できるか *)
+let is_agari (tiles : Tile.tile list) : bool =
+  List.length tiles = 14 && find_agari_patterns tiles <> []

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_mahjong)
+ (libraries mahjong_core ounit2))

--- a/test/test_mahjong.ml
+++ b/test/test_mahjong.ml
@@ -1,0 +1,113 @@
+open OUnit2
+open Mahjong_core
+
+(** ヘルパー: 数牌を簡単に作る *)
+let m n = Tile.Suhai (Tile.Manzu, n)
+let p n = Tile.Suhai (Tile.Pinzu, n)
+let s n = Tile.Suhai (Tile.Souzu, n)
+let ton = Tile.Jihai Tile.Ton
+let haku = Tile.Jihai Tile.Haku
+
+(* === Tile tests === *)
+
+let test_tile_to_string _ =
+  assert_equal "1m" (Tile.to_string (m 1));
+  assert_equal "9p" (Tile.to_string (p 9));
+  assert_equal "5s" (Tile.to_string (s 5));
+  assert_equal "1z" (Tile.to_string ton);
+  assert_equal "5z" (Tile.to_string haku)
+
+let test_tile_compare _ =
+  assert_equal 0 (Tile.compare (m 1) (m 1));
+  assert_bool "1m < 2m" (Tile.compare (m 1) (m 2) < 0);
+  assert_bool "manzu < pinzu" (Tile.compare (m 9) (p 1) < 0);
+  assert_bool "suhai < jihai" (Tile.compare (s 9) ton < 0)
+
+let test_all_tiles_count _ =
+  assert_equal 136 (List.length Tile.all_tiles)
+
+(* === Mentsu tests === *)
+
+let test_is_shuntsu _ =
+  assert_bool "1m2m3m is shuntsu" (Mentsu.is_shuntsu (m 1) (m 2) (m 3));
+  assert_bool "7p8p9p is shuntsu" (Mentsu.is_shuntsu (p 7) (p 8) (p 9));
+  assert_bool "1m2m3p is not shuntsu" (not (Mentsu.is_shuntsu (m 1) (m 2) (p 3)));
+  assert_bool "1m3m5m is not shuntsu" (not (Mentsu.is_shuntsu (m 1) (m 3) (m 5)))
+
+let test_is_koutsu _ =
+  assert_bool "1m1m1m is koutsu" (Mentsu.is_koutsu (m 1) (m 1) (m 1));
+  assert_bool "ton ton ton is koutsu" (Mentsu.is_koutsu ton ton ton);
+  assert_bool "1m2m3m is not koutsu" (not (Mentsu.is_koutsu (m 1) (m 2) (m 3)))
+
+(* === Hand tests === *)
+
+let test_hand_tsumo _ =
+  let hand = Hand.make [m 1; m 2; m 3] in
+  assert_equal 3 (Hand.count hand);
+  match Hand.tsumo (m 4) hand with
+  | Ok hand2 ->
+    assert_equal 4 (Hand.count hand2);
+    assert_equal (Some (m 4)) hand2.tsumo
+  | Error _ -> assert_failure "tsumo should succeed"
+
+let test_hand_discard _ =
+  let hand = Hand.make [m 1; m 2; m 3] in
+  match Hand.discard (m 2) hand with
+  | Ok hand2 ->
+    assert_equal 2 (Hand.count hand2);
+    assert_equal None hand2.tsumo
+  | Error _ -> assert_failure "discard should succeed"
+
+let test_hand_discard_not_found _ =
+  let hand = Hand.make [m 1; m 2; m 3] in
+  match Hand.discard (m 9) hand with
+  | Ok _ -> assert_failure "discard should fail"
+  | Error _ -> ()
+
+(* === Agari tests === *)
+
+let test_agari_basic _ =
+  (* 1m2m3m 4m5m6m 7m8m9m 1p2p3p 5s5s : 基本的な和了形 *)
+  let tiles = [m 1; m 2; m 3; m 4; m 5; m 6; m 7; m 8; m 9;
+               p 1; p 2; p 3; s 5; s 5] in
+  assert_bool "should be agari" (Mentsu.is_agari tiles)
+
+let test_agari_all_koutsu _ =
+  (* 1m1m1m 5p5p5p 9s9s9s 東東東 白白 : 対々和 *)
+  let tiles = [m 1; m 1; m 1; p 5; p 5; p 5; s 9; s 9; s 9;
+               ton; ton; ton; haku; haku] in
+  assert_bool "should be agari (toitoi)" (Mentsu.is_agari tiles)
+
+let test_not_agari _ =
+  let tiles = [m 1; m 2; m 4; m 5; m 6; m 7; m 8; m 9;
+               p 1; p 2; p 3; s 5; s 5; s 6] in
+  assert_bool "should not be agari" (not (Mentsu.is_agari tiles))
+
+(* === Tenpai tests === *)
+
+let test_tenpai _ =
+  (* 1m2m3m 4m5m6m 7m8m9m 1p2p3p 5s : 5s待ち *)
+  let hand = Hand.make [m 1; m 2; m 3; m 4; m 5; m 6; m 7; m 8; m 9;
+                         p 1; p 2; p 3; s 5] in
+  let waits = Hand.tenpai_tiles hand in
+  assert_bool "5s should be a wait" (List.exists (fun t -> Tile.compare t (s 5) = 0) waits)
+
+(* === Test suite === *)
+
+let suite =
+  "Mahjong" >::: [
+    "tile_to_string" >:: test_tile_to_string;
+    "tile_compare" >:: test_tile_compare;
+    "all_tiles_count" >:: test_all_tiles_count;
+    "is_shuntsu" >:: test_is_shuntsu;
+    "is_koutsu" >:: test_is_koutsu;
+    "hand_tsumo" >:: test_hand_tsumo;
+    "hand_discard" >:: test_hand_discard;
+    "hand_discard_not_found" >:: test_hand_discard_not_found;
+    "agari_basic" >:: test_agari_basic;
+    "agari_all_koutsu" >:: test_agari_all_koutsu;
+    "not_agari" >:: test_not_agari;
+    "tenpai" >:: test_tenpai;
+  ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary
- `mentsu.ml`: 順子・刻子の判定、和了パターン探索（4面子1雀頭分解）、和了判定
- `hand.ml`: 手牌管理（ツモ・打牌・ソート）、テンパイ判定・待ち牌算出
- OUnit2テスト12ケース追加（全パス）

## Test plan
- [x] `docker compose run --rm ocaml dune test` 全テスト通過
- [x] `docker compose run --rm ocaml dune build` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)