### PR TITLE
Add game management: wall, player, round progression

### DIFF
--- a/src/core/game.ml
+++ b/src/core/game.ml
@@ -1,0 +1,222 @@
+(** ゲーム進行管理 *)
+
+(** 局の風 *)
+type bakaze = Tile.jihai
+
+(** ゲームのフェーズ *)
+type phase =
+  | WaitingDraw        (** ツモ待ち *)
+  | WaitingDiscard      (** 打牌待ち *)
+  | WaitingCall         (** 鳴き判定待ち *)
+  | RoundEnd            (** 局終了 *)
+  | GameEnd             (** ゲーム終了 *)
+
+(** 局の状態 *)
+type round = {
+  bakaze : bakaze;             (** 場風 *)
+  kyoku : int;                 (** 局数 (1-4) *)
+  honba : int;                 (** 本場 *)
+  riichi_sticks : int;         (** リーチ棒の数 *)
+  wall : Wall.t;               (** 牌山 *)
+  players : Player.t array;    (** プレイヤー（東=0, 南=1, 西=2, 北=3） *)
+  current_turn : int;          (** 現在の手番 (0-3) *)
+  phase : phase;               (** フェーズ *)
+  last_discard : Tile.tile option;       (** 直前の捨て牌 *)
+  last_discard_player : int option;      (** 直前の捨て牌のプレイヤー *)
+}
+
+(** 自風を局数から決定 *)
+let jikaze_of_seat (kyoku : int) (seat : int) : Tile.jihai =
+  let pos = (seat - (kyoku - 1) + 4) mod 4 in
+  match pos with
+  | 0 -> Tile.Ton
+  | 1 -> Tile.Nan
+  | 2 -> Tile.Sha
+  | 3 -> Tile.Pei
+  | _ -> Tile.Ton
+
+(** 配牌 *)
+let deal (wall : Wall.t) : (Tile.tile list array * Wall.t) =
+  let hands = Array.make 4 [] in
+  let w = ref wall in
+  (* 4枚ずつ3回 = 12枚 *)
+  for round_num = 0 to 2 do
+    ignore round_num;
+    for seat = 0 to 3 do
+      for _ = 0 to 3 do
+        match Wall.draw !w with
+        | Some (tile, new_wall) ->
+          hands.(seat) <- tile :: hands.(seat);
+          w := new_wall
+        | None -> ()
+      done
+    done
+  done;
+  (* 1枚ずつ1回 = 13枚 *)
+  for seat = 0 to 3 do
+    match Wall.draw !w with
+    | Some (tile, new_wall) ->
+      hands.(seat) <- tile :: hands.(seat);
+      w := new_wall
+    | None -> ()
+  done;
+  (hands, !w)
+
+(** 新しい局を開始 *)
+let new_round (bakaze : bakaze) (kyoku : int) (honba : int) (riichi_sticks : int)
+    (scores : int array) : round =
+  let wall = Wall.create () in
+  let (dealt_hands, wall_after_deal) = deal wall in
+  let players = Array.init 4 (fun i ->
+    let jikaze = jikaze_of_seat kyoku i in
+    let p = Player.create jikaze in
+    { p with hand = Hand.make dealt_hands.(i); score = scores.(i) }
+  ) in
+  (* 親（東家）がツモ *)
+  let oya = (kyoku - 1) mod 4 in
+  {
+    bakaze;
+    kyoku;
+    honba;
+    riichi_sticks;
+    wall = wall_after_deal;
+    players;
+    current_turn = oya;
+    phase = WaitingDraw;
+    last_discard = None;
+    last_discard_player = None;
+  }
+
+(** ゲーム開始（東1局から） *)
+let start () : round =
+  new_round Tile.Ton 1 0 0 [|25000; 25000; 25000; 25000|]
+
+(** ツモを実行 *)
+let draw_tile (game : round) : (round, string) result =
+  if game.phase <> WaitingDraw then Error "ツモのフェーズではありません"
+  else
+    match Wall.draw game.wall with
+    | None -> Ok { game with phase = RoundEnd }  (* 流局 *)
+    | Some (tile, new_wall) ->
+      let player = game.players.(game.current_turn) in
+      match Player.tsumo tile player with
+      | Ok new_player ->
+        let players = Array.copy game.players in
+        players.(game.current_turn) <- new_player;
+        Ok { game with wall = new_wall; players; phase = WaitingDiscard }
+      | Error e -> Error e
+
+(** 打牌を実行 *)
+let discard_tile (game : round) (tile : Tile.tile) : (round, string) result =
+  if game.phase <> WaitingDiscard then Error "打牌のフェーズではありません"
+  else
+    let player = game.players.(game.current_turn) in
+    match Player.discard tile player with
+    | Ok new_player ->
+      let players = Array.copy game.players in
+      players.(game.current_turn) <- new_player;
+      Ok { game with
+           players;
+           phase = WaitingCall;
+           last_discard = Some tile;
+           last_discard_player = Some game.current_turn }
+    | Error e -> Error e
+
+(** 鳴きがなければ次の手番に進む *)
+let advance_turn (game : round) : round =
+  let next = (game.current_turn + 1) mod 4 in
+  { game with current_turn = next; phase = WaitingDraw }
+
+(** ロン和了の処理 *)
+let ron (game : round) (winner : int) : (round, string) result =
+  match game.last_discard with
+  | None -> Error "ロンできる捨て牌がありません"
+  | Some tile ->
+    let player = game.players.(winner) in
+    let tiles = tile :: player.hand.tiles in
+    let ctx = {
+      Yaku.is_tsumo = false;
+      is_riichi = player.is_riichi;
+      is_ippatsu = player.is_ippatsu;
+      is_tenhou = false;
+      is_chiihou = false;
+      bakaze = game.bakaze;
+      jikaze = player.jikaze;
+    } in
+    let is_oya = player.jikaze = Tile.Ton in
+    match Scoring.score_hand tiles ctx is_oya with
+    | None -> Error "役がありません"
+    | Some result ->
+      let loser = match game.last_discard_player with Some p -> p | None -> 0 in
+      let players = Array.copy game.players in
+      let total_with_honba = result.total + game.honba * 300 in
+      let total_with_riichi = total_with_honba + game.riichi_sticks * 1000 in
+      players.(winner) <- Player.add_score total_with_riichi players.(winner);
+      players.(loser) <- Player.add_score (-total_with_honba) players.(loser);
+      Ok { game with players; phase = RoundEnd; riichi_sticks = 0 }
+
+(** ツモ和了の処理 *)
+let tsumo_agari (game : round) : (round, string) result =
+  let player = game.players.(game.current_turn) in
+  let ctx = {
+    Yaku.is_tsumo = true;
+    is_riichi = player.is_riichi;
+    is_ippatsu = player.is_ippatsu;
+    is_tenhou = false;
+    is_chiihou = false;
+    bakaze = game.bakaze;
+    jikaze = player.jikaze;
+  } in
+  let is_oya = player.jikaze = Tile.Ton in
+  match Scoring.score_hand player.hand.tiles ctx is_oya with
+  | None -> Error "役がありません"
+  | Some result ->
+    let players = Array.copy game.players in
+    let winner = game.current_turn in
+    (match result.payments with
+     | Scoring.Tsumo_oya ko_pay ->
+       let total_each = ko_pay + game.honba * 100 in
+       for i = 0 to 3 do
+         if i <> winner then
+           players.(i) <- Player.add_score (-total_each) players.(i)
+       done;
+       players.(winner) <- Player.add_score (total_each * 3 + game.riichi_sticks * 1000) players.(winner)
+     | Scoring.Tsumo_ko (oya_pay, ko_pay) ->
+       for i = 0 to 3 do
+         if i <> winner then begin
+           let pay = (if players.(i).jikaze = Tile.Ton then oya_pay else ko_pay) + game.honba * 100 in
+           players.(i) <- Player.add_score (-pay) players.(i)
+         end
+       done;
+       let total_in = (oya_pay + ko_pay * 2) + game.honba * 300 + game.riichi_sticks * 1000 in
+       players.(winner) <- Player.add_score total_in players.(winner)
+     | Scoring.Ron _ -> ());  (* ツモなのにロンにはならない *)
+    Ok { game with players; phase = RoundEnd; riichi_sticks = 0 }
+
+(** リーチ宣言 *)
+let declare_riichi (game : round) : (round, string) result =
+  let player = game.players.(game.current_turn) in
+  match Player.declare_riichi player with
+  | Ok new_player ->
+    let players = Array.copy game.players in
+    players.(game.current_turn) <- new_player;
+    Ok { game with players; riichi_sticks = game.riichi_sticks + 1 }
+  | Error e -> Error e
+
+(** 次の局に進む *)
+let next_round (game : round) (oya_won : bool) : round =
+  let scores = Array.map (fun (p : Player.t) -> p.score) game.players in
+  if oya_won then
+    (* 親の連荘 *)
+    new_round game.bakaze game.kyoku (game.honba + 1) game.riichi_sticks scores
+  else
+    let next_kyoku = game.kyoku + 1 in
+    if next_kyoku > 4 then
+      match game.bakaze with
+      | Tile.Ton ->
+        new_round Tile.Nan 1 0 game.riichi_sticks scores
+      | _ ->
+        (* 南4局終了 → ゲーム終了（簡略化） *)
+        { game with phase = GameEnd }
+    else
+      new_round game.bakaze next_kyoku 0 game.riichi_sticks scores

--- a/src/core/player.ml
+++ b/src/core/player.ml
@@ -1,0 +1,95 @@
+(** プレイヤーの管理 *)
+
+(** 副露（鳴き）の種類 *)
+type furo =
+  | Chi of Tile.tile * Tile.tile * Tile.tile     (** チー: 順子 *)
+  | Pon of Tile.tile                              (** ポン: 刻子 *)
+  | Minkan of Tile.tile                           (** 明槓 *)
+  | Ankan of Tile.tile                            (** 暗槓 *)
+
+(** プレイヤーの状態 *)
+type t = {
+  hand : Hand.t;               (** 手牌 *)
+  furo_list : furo list;       (** 副露リスト *)
+  kawa : Tile.tile list;       (** 河（捨て牌） *)
+  is_riichi : bool;            (** リーチ宣言済みか *)
+  is_ippatsu : bool;           (** 一発の可能性があるか *)
+  jikaze : Tile.jihai;         (** 自風 *)
+  score : int;                 (** 持ち点 *)
+}
+
+(** プレイヤーを初期化 *)
+let create (jikaze : Tile.jihai) : t = {
+  hand = Hand.empty;
+  furo_list = [];
+  kawa = [];
+  is_riichi = false;
+  is_ippatsu = false;
+  jikaze;
+  score = 25000;
+}
+
+(** 門前か（副露なし、暗槓は除く） *)
+let is_menzen (player : t) : bool =
+  List.for_all (fun f ->
+    match f with Ankan _ -> true | _ -> false
+  ) player.furo_list
+
+(** 手牌に牌を加える（ツモ） *)
+let tsumo (tile : Tile.tile) (player : t) : (t, string) result =
+  match Hand.tsumo tile player.hand with
+  | Ok hand -> Ok { player with hand; is_ippatsu = player.is_ippatsu }
+  | Error e -> Error e
+
+(** 牌を捨てる *)
+let discard (tile : Tile.tile) (player : t) : (t, string) result =
+  match Hand.discard tile player.hand with
+  | Ok hand -> Ok { player with hand; kawa = tile :: player.kawa; is_ippatsu = false }
+  | Error e -> Error e
+
+(** リーチ宣言 *)
+let declare_riichi (player : t) : (t, string) result =
+  if not (is_menzen player) then Error "門前でないためリーチできません"
+  else if player.score < 1000 then Error "持ち点が1000点未満のためリーチできません"
+  else if player.is_riichi then Error "既にリーチ宣言済みです"
+  else Ok { player with is_riichi = true; is_ippatsu = true; score = player.score - 1000 }
+
+(** ポン *)
+let pon (tile : Tile.tile) (player : t) : (t, string) result =
+  let hand_tiles = player.hand.tiles in
+  let count = List.length (List.filter (fun t -> Tile.compare t tile = 0) hand_tiles) in
+  if count < 2 then Error "ポンできる牌がありません"
+  else
+    match Mentsu.remove_one tile hand_tiles with
+    | Some rest1 ->
+      (match Mentsu.remove_one tile rest1 with
+       | Some rest2 ->
+         Ok { player with
+              hand = Hand.make rest2;
+              furo_list = Pon tile :: player.furo_list;
+              is_ippatsu = false }
+       | None -> Error "ポンできる牌がありません")
+    | None -> Error "ポンできる牌がありません"
+
+(** チー *)
+let chi (t1 : Tile.tile) (t2 : Tile.tile) (taken : Tile.tile) (player : t) : (t, string) result =
+  let all = [t1; t2; taken] in
+  let sorted = List.sort Tile.compare all in
+  match sorted with
+  | [a; b; c] when Mentsu.is_shuntsu a b c ->
+    let hand_tiles = player.hand.tiles in
+    (match Mentsu.remove_one t1 hand_tiles with
+     | Some rest1 ->
+       (match Mentsu.remove_one t2 rest1 with
+        | Some rest2 ->
+          Ok { player with
+               hand = Hand.make rest2;
+               furo_list = Chi (a, b, c) :: player.furo_list;
+               is_ippatsu = false }
+        | None -> Error "チーできる牌がありません")
+     | None -> Error "チーできる牌がありません")
+  | _ -> Error "順子になりません"
+
+(** 持ち点を加減する *)
+let add_score (diff : int) (player : t) : t =
+  { player with score = player.score + diff }

--- a/src/core/wall.ml
+++ b/src/core/wall.ml
@@ -1,0 +1,59 @@
+(** 山（牌山）の管理 *)
+
+type t = {
+  tiles : Tile.tile array;   (** 牌山 *)
+  position : int;            (** 現在のツモ位置 *)
+  dead_wall : int;           (** 王牌の開始位置（残り14枚） *)
+}
+
+(** Fisher-Yatesシャッフル *)
+let shuffle arr =
+  let n = Array.length arr in
+  for i = n - 1 downto 1 do
+    let j = Random.int (i + 1) in
+    let tmp = arr.(i) in
+    arr.(i) <- arr.(j);
+    arr.(j) <- tmp
+  done
+
+(** 山を作成（シャッフル済み） *)
+let create () : t =
+  let tiles = Array.of_list Tile.all_tiles in
+  shuffle tiles;
+  { tiles; position = 0; dead_wall = 136 - 14 }
+
+(** シード指定で山を作成（テスト用） *)
+let create_with_seed (seed : int) : t =
+  Random.init seed;
+  create ()
+
+(** 牌をツモる *)
+let draw (wall : t) : (Tile.tile * t) option =
+  if wall.position >= wall.dead_wall then None
+  else
+    let tile = wall.tiles.(wall.position) in
+    Some (tile, { wall with position = wall.position + 1 })
+
+(** 残りツモ枚数 *)
+let remaining (wall : t) : int =
+  wall.dead_wall - wall.position
+
+(** ドラ表示牌を取得 *)
+let dora_indicators (wall : t) (kan_count : int) : Tile.tile list =
+  let base = 136 - 5 in  (* 王牌の上から5枚目がドラ表示牌 *)
+  List.init (1 + kan_count) (fun i ->
+    wall.tiles.(base - i * 2)
+  )
+
+(** ドラ表示牌から実際のドラを取得 *)
+let dora_of_indicator (indicator : Tile.tile) : Tile.tile =
+  match indicator with
+  | Tile.Suhai (suit, 9) -> Tile.Suhai (suit, 1)
+  | Tile.Suhai (suit, n) -> Tile.Suhai (suit, n + 1)
+  | Tile.Jihai Tile.Pei -> Tile.Jihai Tile.Ton
+  | Tile.Jihai Tile.Ton -> Tile.Jihai Tile.Nan
+  | Tile.Jihai Tile.Nan -> Tile.Jihai Tile.Sha
+  | Tile.Jihai Tile.Sha -> Tile.Jihai Tile.Pei
+  | Tile.Jihai Tile.Chun -> Tile.Jihai Tile.Haku
+  | Tile.Jihai Tile.Haku -> Tile.Jihai Tile.Hatsu
+  | Tile.Jihai Tile.Hatsu -> Tile.Jihai Tile.Chun

--- a/test/test_mahjong.ml
+++ b/test/test_mahjong.ml
@@ -215,6 +215,104 @@ let test_score_hand_integration _ =
     assert_bool "han >= 4" (result.han_detail >= 4)
   | None -> assert_failure "should score"
 
+(* === Wall tests === *)
+
+let test_wall_create _ =
+  let wall = Wall.create_with_seed 42 in
+  assert_equal 122 (Wall.remaining wall)  (* 136 - 14(王牌) = 122 *)
+
+let test_wall_draw _ =
+  let wall = Wall.create_with_seed 42 in
+  match Wall.draw wall with
+  | Some (_, new_wall) ->
+    assert_equal 121 (Wall.remaining new_wall)
+  | None -> assert_failure "should draw"
+
+let test_wall_dora_indicator _ =
+  let wall = Wall.create_with_seed 42 in
+  let indicators = Wall.dora_indicators wall 0 in
+  assert_equal 1 (List.length indicators)
+
+let test_dora_of_indicator _ =
+  (* 1m → 2m *)
+  assert_equal (m 2) (Wall.dora_of_indicator (m 1));
+  (* 9m → 1m *)
+  assert_equal (m 1) (Wall.dora_of_indicator (m 9));
+  (* 北 → 東 *)
+  assert_equal (Tile.Jihai Tile.Ton) (Wall.dora_of_indicator (Tile.Jihai Tile.Pei));
+  (* 中 → 白 *)
+  assert_equal haku (Wall.dora_of_indicator chun)
+
+(* === Player tests === *)
+
+let test_player_create _ =
+  let player = Player.create Tile.Ton in
+  assert_equal 25000 player.score;
+  assert_bool "menzen" (Player.is_menzen player);
+  assert_equal false player.is_riichi
+
+let test_player_pon _ =
+  let player = { (Player.create Tile.Ton) with hand = Hand.make [m 1; m 1; m 2; m 3] } in
+  match Player.pon (m 1) player with
+  | Ok new_player ->
+    assert_equal 2 (Hand.count new_player.hand);
+    assert_bool "not menzen after pon" (not (Player.is_menzen new_player))
+  | Error e -> assert_failure e
+
+(* === Game tests === *)
+
+let test_game_start _ =
+  let game = Game.start () in
+  assert_equal Game.WaitingDraw game.phase;
+  (* 全員13枚配牌 *)
+  Array.iter (fun (p : Player.t) ->
+    assert_equal 13 (Hand.count p.hand)
+  ) game.players;
+  (* 持ち点合計10万点 *)
+  let total_score = Array.fold_left (fun acc (p : Player.t) -> acc + p.score) 0 game.players in
+  assert_equal 100000 total_score
+
+let test_game_draw_and_discard _ =
+  let game = Game.start () in
+  match Game.draw_tile game with
+  | Ok game2 ->
+    assert_equal Game.WaitingDiscard game2.phase;
+    let player = game2.players.(game2.current_turn) in
+    assert_equal 14 (Hand.count player.hand);
+    (* 最初の牌を捨てる *)
+    let tile = List.hd player.hand.tiles in
+    (match Game.discard_tile game2 tile with
+     | Ok game3 ->
+       assert_equal Game.WaitingCall game3.phase;
+       assert_equal (Some tile) game3.last_discard
+     | Error e -> assert_failure e)
+  | Error e -> assert_failure e
+
+let test_game_advance_turn _ =
+  let game = Game.start () in
+  let initial_turn = game.current_turn in
+  match Game.draw_tile game with
+  | Ok game2 ->
+    let player = game2.players.(game2.current_turn) in
+    let tile = List.hd player.hand.tiles in
+    (match Game.discard_tile game2 tile with
+     | Ok game3 ->
+       let game4 = Game.advance_turn game3 in
+       assert_equal ((initial_turn + 1) mod 4) game4.current_turn;
+       assert_equal Game.WaitingDraw game4.phase
+     | Error e -> assert_failure e)
+  | Error e -> assert_failure e
+
+let test_jikaze_assignment _ =
+  (* 東1局: seat0=東, seat1=南, seat2=西, seat3=北 *)
+  assert_equal Tile.Ton (Game.jikaze_of_seat 1 0);
+  assert_equal Tile.Nan (Game.jikaze_of_seat 1 1);
+  assert_equal Tile.Sha (Game.jikaze_of_seat 1 2);
+  assert_equal Tile.Pei (Game.jikaze_of_seat 1 3);
+  (* 東2局: seat1=東 *)
+  assert_equal Tile.Pei (Game.jikaze_of_seat 2 0);
+  assert_equal Tile.Ton (Game.jikaze_of_seat 2 1)
+
 (* === Test suite === *)
 
 let suite =
@@ -244,6 +342,16 @@ let suite =
     "scoring_ko_tsumo" >:: test_scoring_ko_tsumo;
     "scoring_yakuman" >:: test_scoring_yakuman;
     "score_hand_integration" >:: test_score_hand_integration;
+    "wall_create" >:: test_wall_create;
+    "wall_draw" >:: test_wall_draw;
+    "wall_dora_indicator" >:: test_wall_dora_indicator;
+    "dora_of_indicator" >:: test_dora_of_indicator;
+    "player_create" >:: test_player_create;
+    "player_pon" >:: test_player_pon;
+    "game_start" >:: test_game_start;
+    "game_draw_and_discard" >:: test_game_draw_and_discard;
+    "game_advance_turn" >:: test_game_advance_turn;
+    "jikaze_assignment" >:: test_jikaze_assignment;
   ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary
- `wall.ml`: 牌山管理（Fisher-Yatesシャッフル、ツモ、王牌、ドラ表示牌→実ドラ変換）
- `player.ml`: プレイヤー状態管理（手牌、副露（ポン・チー・暗槓・明槓）、河、リーチ宣言、門前判定）
- `game.ml`: 局進行管理（配牌、ツモ→打牌→鳴き判定のフェーズ遷移、ロン・ツモ和了の点数精算、連荘・局進行・場風管理）
- テスト10ケース追加（全35テスト通過）

## Test plan
- [x] `docker compose run --rm ocaml dune test` 全35テスト通過
- [x] `docker compose run --rm ocaml dune build` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)