### PR TITLE
Add Melange JS bindings and TypeScript bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 _build/
 *.bs.js
 .melange.eobjs/
+src/generated/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /home/opam/app
 RUN opam install dune melange melange-testing-library ounit2 -y
 
 COPY --chown=opam:opam src/core/ src/core/
+COPY --chown=opam:opam src/bindings/ src/bindings/
+COPY --chown=opam:opam test/ test/
 COPY --chown=opam:opam dune-project .
 
 CMD ["dune", "build"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,7 @@ services:
     build: .
     volumes:
       - ./src/core:/home/opam/app/src/core
+      - ./src/bindings:/home/opam/app/src/bindings
+      - ./test:/home/opam/app/test
       - ./dune-project:/home/opam/app/dune-project
     command: dune build --watch

--- a/scripts/copy-melange-output.sh
+++ b/scripts/copy-melange-output.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# MelangeのJS出力をフロントエンドから参照できる位置にコピーする
+set -e
+
+CONTAINER_OUTPUT="/home/opam/app/_build/default/src/bindings/output"
+LOCAL_OUTPUT="./src/generated"
+
+mkdir -p "$LOCAL_OUTPUT"
+
+docker compose run --rm ocaml bash -c "
+  dune build && \
+  tar cf - -C $CONTAINER_OUTPUT .
+" | tar xf - -C "$LOCAL_OUTPUT"
+
+echo "Melange output copied to $LOCAL_OUTPUT"

--- a/src/bindings/dune
+++ b/src/bindings/dune
@@ -1,0 +1,4 @@
+(melange.emit
+ (target output)
+ (libraries mahjong_core)
+ (module_systems es6))

--- a/src/bindings/mahjong_js.ml
+++ b/src/bindings/mahjong_js.ml
@@ -1,0 +1,216 @@
+(** Melange JS バインディング - JSON文字列でJS/OCaml間をブリッジ *)
+
+open Mahjong_core
+
+(** === JSON エンコーダ === *)
+
+let json_str s = "\"" ^ s ^ "\""
+let json_int n = string_of_int n
+let json_bool b = if b then "true" else "false"
+let json_null = "null"
+let json_obj fields =
+  "{" ^ String.concat "," (List.map (fun (k, v) -> "\"" ^ k ^ "\":" ^ v) fields) ^ "}"
+let json_arr items =
+  "[" ^ String.concat "," items ^ "]"
+
+let tile_to_json (tile : Tile.tile) : string =
+  match tile with
+  | Tile.Suhai (suit, n) ->
+    let suit_str = match suit with
+      | Tile.Manzu -> "manzu" | Tile.Pinzu -> "pinzu" | Tile.Souzu -> "souzu"
+    in
+    json_obj [("kind", json_str "suhai"); ("suit", json_str suit_str);
+              ("number", json_int n); ("label", json_str (Tile.to_string tile))]
+  | Tile.Jihai j ->
+    let suit_str = match j with
+      | Tile.Ton | Tile.Nan | Tile.Sha | Tile.Pei -> "kaze"
+      | Tile.Haku | Tile.Hatsu | Tile.Chun -> "sangen"
+    in
+    let number = match j with
+      | Tile.Ton -> 1 | Tile.Nan -> 2 | Tile.Sha -> 3 | Tile.Pei -> 4
+      | Tile.Haku -> 5 | Tile.Hatsu -> 6 | Tile.Chun -> 7
+    in
+    json_obj [("kind", json_str "jihai"); ("suit", json_str suit_str);
+              ("number", json_int number); ("label", json_str (Tile.to_string tile))]
+
+let yaku_to_json (y : Yaku.yaku) : string =
+  json_obj [("name", json_str (Yaku.name_of_yaku y)); ("han", json_int (Yaku.han_of_yaku y))]
+
+let payment_to_json (p : Scoring.payment) : string =
+  match p with
+  | Scoring.Ron n ->
+    json_obj [("kind", json_str "ron"); ("ron", json_int n)]
+  | Scoring.Tsumo_oya n ->
+    json_obj [("kind", json_str "tsumo_oya"); ("ko_pay", json_int n)]
+  | Scoring.Tsumo_ko (oya, ko) ->
+    json_obj [("kind", json_str "tsumo_ko"); ("oya_pay", json_int oya); ("ko_pay", json_int ko)]
+
+let player_to_json (p : Player.t) : string =
+  let hand = json_arr (List.map tile_to_json p.hand.tiles) in
+  let kawa = json_arr (List.rev_map tile_to_json p.kawa) in
+  let jikaze_str = match p.jikaze with
+    | Tile.Ton -> "ton" | Tile.Nan -> "nan"
+    | Tile.Sha -> "sha" | Tile.Pei -> "pei"
+    | _ -> "ton"
+  in
+  json_obj [
+    ("hand", hand); ("kawa", kawa); ("score", json_int p.score);
+    ("is_riichi", json_bool p.is_riichi); ("is_menzen", json_bool (Player.is_menzen p));
+    ("jikaze", json_str jikaze_str)
+  ]
+
+let game_state_to_json (game : Game.round) : string =
+  let players = json_arr (Array.to_list (Array.map player_to_json game.players)) in
+  let phase_str = match game.phase with
+    | Game.WaitingDraw -> "waiting_draw" | Game.WaitingDiscard -> "waiting_discard"
+    | Game.WaitingCall -> "waiting_call" | Game.RoundEnd -> "round_end"
+    | Game.GameEnd -> "game_end"
+  in
+  let bakaze_str = match game.bakaze with
+    | Tile.Ton -> "ton" | Tile.Nan -> "nan"
+    | Tile.Sha -> "sha" | Tile.Pei -> "pei"
+    | _ -> "ton"
+  in
+  let last_d = match game.last_discard with
+    | Some t -> tile_to_json t | None -> json_null
+  in
+  json_obj [
+    ("players", players); ("current_turn", json_int game.current_turn);
+    ("phase", json_str phase_str); ("bakaze", json_str bakaze_str);
+    ("kyoku", json_int game.kyoku); ("honba", json_int game.honba);
+    ("remaining_tiles", json_int (Wall.remaining game.wall));
+    ("last_discard", last_d)
+  ]
+
+(** === JS向けAPI === *)
+
+let game_ref : Game.round option ref = ref None
+
+let tile_of_kind_suit_number kind suit number =
+  if kind = "suhai" then
+    let s = match suit with
+      | "manzu" -> Tile.Manzu | "pinzu" -> Tile.Pinzu | _ -> Tile.Souzu
+    in
+    Tile.Suhai (s, number)
+  else
+    match number with
+    | 1 -> Tile.Jihai Tile.Ton | 2 -> Tile.Jihai Tile.Nan
+    | 3 -> Tile.Jihai Tile.Sha | 4 -> Tile.Jihai Tile.Pei
+    | 5 -> Tile.Jihai Tile.Haku | 6 -> Tile.Jihai Tile.Hatsu
+    | _ -> Tile.Jihai Tile.Chun
+
+let start_game () : string =
+  let game = Game.start () in
+  game_ref := Some game;
+  game_state_to_json game
+
+let get_state () : string =
+  match !game_ref with
+  | Some game -> game_state_to_json game
+  | None -> json_null
+
+let draw_tile () : string =
+  match !game_ref with
+  | None -> json_null
+  | Some game ->
+    match Game.draw_tile game with
+    | Ok new_game -> game_ref := Some new_game; game_state_to_json new_game
+    | Error _ -> json_null
+
+let discard_tile kind suit number : string =
+  match !game_ref with
+  | None -> json_null
+  | Some game ->
+    let tile = tile_of_kind_suit_number kind suit number in
+    match Game.discard_tile game tile with
+    | Ok new_game -> game_ref := Some new_game; game_state_to_json new_game
+    | Error _ -> json_null
+
+let advance_turn () : string =
+  match !game_ref with
+  | None -> json_null
+  | Some game ->
+    let new_game = Game.advance_turn game in
+    game_ref := Some new_game;
+    game_state_to_json new_game
+
+let check_tsumo () : string =
+  match !game_ref with
+  | None -> json_null
+  | Some game ->
+    let player = game.players.(game.current_turn) in
+    let ctx = {
+      Yaku.is_tsumo = true; is_riichi = player.is_riichi;
+      is_ippatsu = false; is_tenhou = false; is_chiihou = false;
+      bakaze = game.bakaze; jikaze = player.jikaze;
+    } in
+    let is_oya = player.jikaze = Tile.Ton in
+    match Scoring.score_hand player.hand.tiles ctx is_oya with
+    | Some result ->
+      (match Game.tsumo_agari game with
+       | Ok new_game ->
+         game_ref := Some new_game;
+         json_obj [
+           ("state", game_state_to_json new_game);
+           ("yakus", json_arr (List.map yaku_to_json result.yakus));
+           ("han", json_int result.han_detail);
+           ("fu", json_int result.fu_detail);
+           ("total", json_int result.total);
+           ("payment", payment_to_json result.payments)
+         ]
+       | Error _ -> json_null)
+    | None -> json_null
+
+let check_ron seat : string =
+  match !game_ref with
+  | None -> json_null
+  | Some game ->
+    match game.last_discard with
+    | None -> json_null
+    | Some tile ->
+      let player = game.players.(seat) in
+      let tiles = tile :: player.hand.tiles in
+      let ctx = {
+        Yaku.is_tsumo = false; is_riichi = player.is_riichi;
+        is_ippatsu = false; is_tenhou = false; is_chiihou = false;
+        bakaze = game.bakaze; jikaze = player.jikaze;
+      } in
+      let is_oya = player.jikaze = Tile.Ton in
+      (match Scoring.score_hand tiles ctx is_oya with
+       | Some result ->
+         (match Game.ron game seat with
+          | Ok new_game ->
+            game_ref := Some new_game;
+            json_obj [
+              ("state", game_state_to_json new_game);
+              ("yakus", json_arr (List.map yaku_to_json result.yakus));
+              ("han", json_int result.han_detail);
+              ("fu", json_int result.fu_detail);
+              ("total", json_int result.total);
+              ("payment", payment_to_json result.payments)
+            ]
+          | Error _ -> json_null)
+       | None -> json_null)
+
+let declare_riichi () : string =
+  match !game_ref with
+  | None -> json_null
+  | Some game ->
+    match Game.declare_riichi game with
+    | Ok new_game -> game_ref := Some new_game; game_state_to_json new_game
+    | Error _ -> json_null
+
+let get_tenpai () : string =
+  match !game_ref with
+  | None -> json_arr []
+  | Some game ->
+    let player = game.players.(game.current_turn) in
+    json_arr (List.map tile_to_json (Hand.tenpai_tiles player.hand))
+
+let next_round oya_won : string =
+  match !game_ref with
+  | None -> json_null
+  | Some game ->
+    let new_game = Game.next_round game oya_won in
+    game_ref := Some new_game;
+    game_state_to_json new_game

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,4 +1,3 @@
 (library
  (name mahjong_core)
- (modes melange byte)
- (libraries melange))
+ (modes melange byte native))

--- a/src/core/mentsu.ml
+++ b/src/core/mentsu.ml
@@ -74,29 +74,38 @@ let find_agari_patterns (tiles : Tile.tile list) : agari_pattern list =
       !results
   in
 
-  (* 雀頭候補を列挙して、残りから4面子を探す *)
-  let rec try_jantai (tiles : Tile.tile list) : agari_pattern list =
-    match tiles with
-    | [] -> []
-    | t1 :: rest ->
-      let patterns =
-        match remove_one t1 rest with
-        | Some rest_without_pair ->
-          let mentsu_results = extract_mentsu (List.sort Tile.compare rest_without_pair) [] in
-          List.filter_map (fun (ms, leftover) ->
-            if leftover = [] && List.length ms = 4 then
-              Some { mentsu_list = ms; jantai = t1 }
-            else
-              None
-          ) mentsu_results
-        | None -> []
-      in
-      (* 同じ牌の雀頭は一度だけ試す *)
-      let skip_same = List.filter (fun t -> Tile.compare t t1 <> 0) rest in
-      patterns @ try_jantai skip_same
+  (* 一意な雀頭候補を列挙 *)
+  let unique_jantai_candidates =
+    let rec aux seen = function
+      | [] -> []
+      | t :: rest ->
+        if List.exists (fun s -> Tile.compare s t = 0) seen then
+          aux seen rest
+        else
+          (* ペアが存在するか確認 *)
+          let count = List.length (List.filter (fun x -> Tile.compare x t = 0) sorted) in
+          if count >= 2 then t :: aux (t :: seen) rest
+          else aux (t :: seen) rest
+    in
+    aux [] sorted
   in
 
-  try_jantai sorted
+  (* 各雀頭候補について、残りから4面子を探す *)
+  List.concat_map (fun jantai ->
+    match remove_one jantai sorted with
+    | Some rest1 ->
+      (match remove_one jantai rest1 with
+       | Some rest_without_pair ->
+         let mentsu_results = extract_mentsu (List.sort Tile.compare rest_without_pair) [] in
+         List.filter_map (fun (ms, leftover) ->
+           if leftover = [] && List.length ms = 4 then
+             Some { mentsu_list = ms; jantai }
+           else
+             None
+         ) mentsu_results
+       | None -> [])
+    | None -> []
+  ) unique_jantai_candidates
 
 (** 和了判定: 14枚の手牌が4面子1雀頭に分解できるか *)
 let is_agari (tiles : Tile.tile list) : bool =

--- a/src/core/yaku.ml
+++ b/src/core/yaku.ml
@@ -415,7 +415,7 @@ let judge_yaku (pattern : Mentsu.agari_pattern) (ctx : agari_context) : yaku lis
   let add y = yakus := y :: !yakus in
 
   (* 役満チェック *)
-  if check_suuankou pattern then add Suuankou;
+  if check_suuankou pattern && ctx.is_tsumo then add Suuankou;
   if check_daisangen pattern then add Daisangen;
   if check_shousuushii pattern then add Shousuushii;
   if check_daisuushii pattern then add Daisuushii;

--- a/src/mahjong-bridge.ts
+++ b/src/mahjong-bridge.ts
@@ -1,0 +1,149 @@
+/**
+ * OCaml麻雀ロジックへのTypeScriptブリッジ
+ * Melange経由でコンパイルされたJSモジュールをラップする
+ */
+
+// === 型定義 ===
+
+export interface Tile {
+  kind: 'suhai' | 'jihai';
+  suit: 'manzu' | 'pinzu' | 'souzu' | 'kaze' | 'sangen';
+  number: number;
+  label: string;
+}
+
+export interface Player {
+  hand: Tile[];
+  kawa: Tile[];
+  score: number;
+  is_riichi: boolean;
+  is_menzen: boolean;
+  jikaze: 'ton' | 'nan' | 'sha' | 'pei';
+}
+
+export type Phase = 'waiting_draw' | 'waiting_discard' | 'waiting_call' | 'round_end' | 'game_end';
+
+export interface GameState {
+  players: Player[];
+  current_turn: number;
+  phase: Phase;
+  bakaze: 'ton' | 'nan' | 'sha' | 'pei';
+  kyoku: number;
+  honba: number;
+  remaining_tiles: number;
+  last_discard: Tile | null;
+}
+
+export interface Yaku {
+  name: string;
+  han: number;
+}
+
+export interface Payment {
+  kind: 'ron' | 'tsumo_oya' | 'tsumo_ko';
+  ron?: number;
+  oya_pay?: number;
+  ko_pay?: number;
+}
+
+export interface AgariResult {
+  state: GameState;
+  yakus: Yaku[];
+  han: number;
+  fu: number;
+  total: number;
+  payment: Payment;
+}
+
+// === Melange出力のインポート ===
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mahjongJs: any = null;
+
+export async function initMahjong(): Promise<void> {
+  mahjongJs = await import('./generated/src/bindings/mahjong_js.js');
+}
+
+// === API関数 ===
+
+function parse<T>(json: string): T | null {
+  if (json === 'null') return null;
+  try {
+    return JSON.parse(json) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function startGame(): GameState {
+  const json = mahjongJs.start_game();
+  return JSON.parse(json) as GameState;
+}
+
+export function getState(): GameState | null {
+  return parse<GameState>(mahjongJs.get_state());
+}
+
+export function drawTile(): GameState | null {
+  return parse<GameState>(mahjongJs.draw_tile());
+}
+
+export function discardTile(tile: Tile): GameState | null {
+  return parse<GameState>(mahjongJs.discard_tile(tile.kind, tile.suit, tile.number));
+}
+
+export function advanceTurn(): GameState | null {
+  return parse<GameState>(mahjongJs.advance_turn());
+}
+
+export function checkTsumoAgari(): AgariResult | null {
+  return parse<AgariResult>(mahjongJs.check_tsumo());
+}
+
+export function checkRon(winnerSeat: number): AgariResult | null {
+  return parse<AgariResult>(mahjongJs.check_ron(winnerSeat));
+}
+
+export function declareRiichi(): GameState | null {
+  return parse<GameState>(mahjongJs.declare_riichi());
+}
+
+export function getTenpaiTiles(): Tile[] {
+  return JSON.parse(mahjongJs.get_tenpai()) as Tile[];
+}
+
+export function nextRound(oyaWon: boolean): GameState | null {
+  return parse<GameState>(mahjongJs.next_round(oyaWon));
+}
+
+// === ユーティリティ ===
+
+/** 風の日本語名 */
+export function kazeToJa(kaze: string): string {
+  const map: Record<string, string> = { ton: '東', nan: '南', sha: '西', pei: '北' };
+  return map[kaze] ?? kaze;
+}
+
+/** 牌の日本語表示名 */
+export function tileToDisplay(tile: Tile): string {
+  if (tile.kind === 'suhai') {
+    const suitMap: Record<string, string> = { manzu: '萬', pinzu: '筒', souzu: '索' };
+    return `${tile.number}${suitMap[tile.suit]}`;
+  }
+  const jihaiMap: Record<number, string> = {
+    1: '東', 2: '南', 3: '西', 4: '北', 5: '白', 6: '發', 7: '中',
+  };
+  return jihaiMap[tile.number] ?? '';
+}
+
+/** フェーズの日本語表示 */
+export function phaseToJa(phase: Phase): string {
+  const map: Record<Phase, string> = {
+    waiting_draw: 'ツモ待ち',
+    waiting_discard: '打牌待ち',
+    waiting_call: '鳴き判定',
+    round_end: '局終了',
+    game_end: 'ゲーム終了',
+  };
+  return map[phase];
+}


### PR DESCRIPTION
## Summary
- `src/bindings/mahjong_js.ml`: OCamlロジックをJSON文字列ベースでJSに公開するAPI
- `src/mahjong-bridge.ts`: TypeScript型定義 + Melange出力を呼び出すラッパー
- `scripts/copy-melange-output.sh`: DockerコンテナからMelange JS出力をコピーするスクリプト
- Bug fix: `mentsu.ml` の雀頭探索ロジック修正（再帰で牌が消失する問題）
- Bug fix: 四暗刻をツモ時のみ判定するよう修正

## Test plan
- [x] `docker compose run --rm ocaml dune test` 全35テスト通過
- [x] `docker compose run --rm ocaml dune build` ビルド成功（Melange JS出力確認済み）
- [x] `scripts/copy-melange-output.sh` でJS出力をsrc/generatedにコピー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)