### PR TITLE
Add CPU AI with strategic discard logic

### DIFF
--- a/src/bindings/mahjong_js.ml
+++ b/src/bindings/mahjong_js.ml
@@ -214,3 +214,16 @@ let next_round oya_won : string =
     let new_game = Game.next_round game oya_won in
     game_ref := Some new_game;
     game_state_to_json new_game
+
+(** CPU AI の行動を決定 *)
+let ai_decide seat : string =
+  match !game_ref with
+  | None -> json_null
+  | Some game ->
+    let player = game.players.(seat) in
+    match Ai.decide player game.bakaze with
+    | Ai.TsumoAgari -> json_obj [("action", json_str "tsumo")]
+    | Ai.Discard tile ->
+      json_obj [("action", json_str "discard"); ("tile", tile_to_json tile)]
+    | Ai.DeclareRiichi tile ->
+      json_obj [("action", json_str "riichi"); ("tile", tile_to_json tile)]

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -3,7 +3,7 @@ import type { Tile, GameState, AgariResult } from '../mahjong-bridge';
 import {
   startGame, drawTile, discardTile, advanceTurn,
   checkTsumoAgari, checkRon, getTenpaiTiles, nextRound,
-  kazeToJa
+  declareRiichi, aiDecide, kazeToJa
 } from '../mahjong-bridge';
 import { PlayerHand } from './PlayerHand';
 import { Kawa } from './Kawa';
@@ -111,20 +111,27 @@ export function GameBoard() {
       setMessage(`${kazeToJa(drawn.players[drawn.current_turn].jikaze)}家の番...`);
 
       setTimeout(() => {
-        // CPUツモ和了チェック
-        const tsumoResult = checkTsumoAgari();
-        if (tsumoResult) {
-          setState(tsumoResult.state);
-          setAgariResult(tsumoResult);
-          setAgariWinner(`${kazeToJa(drawn.players[drawn.current_turn].jikaze)}家`);
-          return;
+        // CPU AI判定
+        const aiAction = aiDecide(drawn.current_turn);
+        if (!aiAction) return;
+
+        if (aiAction.action === 'tsumo') {
+          const tsumoResult = checkTsumoAgari();
+          if (tsumoResult) {
+            setState(tsumoResult.state);
+            setAgariResult(tsumoResult);
+            setAgariWinner(`${kazeToJa(drawn.players[drawn.current_turn].jikaze)}家`);
+            return;
+          }
         }
 
-        // CPU打牌（最初の牌を捨てる簡易AI）
-        const cpuPlayer = drawn.players[drawn.current_turn];
-        if (cpuPlayer.hand.length > 0) {
-          const tileToDiscard = cpuPlayer.hand[0];
-          const afterDiscard = discardTile(tileToDiscard);
+        if (aiAction.action === 'riichi') {
+          const riichiState = declareRiichi();
+          if (riichiState) setState(riichiState);
+        }
+
+        if (aiAction.tile) {
+          const afterDiscard = discardTile(aiAction.tile);
           if (afterDiscard) {
             setState(afterDiscard);
             setTimeout(() => processAfterDiscard(afterDiscard), 300);
@@ -185,7 +192,6 @@ export function GameBoard() {
 
   // プレイヤーの表示順: 対面(2) → 右(3) → 左(1) → 自分(0)
   const seatOrder = [2, 3, 1, 0];
-  const seatLabels = ['対面', '右', '左', 'あなた'];
 
   const canTsumo = state.phase === 'waiting_discard'
     && state.current_turn === HUMAN_SEAT

--- a/src/core/ai.ml
+++ b/src/core/ai.ml
@@ -1,0 +1,139 @@
+(** CPU思考ロジック *)
+
+(** 牌の有効度（向聴数を下げる可能性）を評価する *)
+
+(** 孤立牌かどうか判定（周囲に関連する牌がない） *)
+let is_isolated tile hand_tiles =
+  let related = match tile with
+    | Tile.Suhai (suit, n) ->
+      let check_exists s num =
+        num >= 1 && num <= 9 &&
+        List.exists (fun t -> Tile.compare t (Tile.Suhai (s, num)) = 0) hand_tiles
+      in
+      check_exists suit (n - 2) || check_exists suit (n - 1) ||
+      check_exists suit (n + 1) || check_exists suit (n + 2)
+    | Tile.Jihai _ ->
+      List.exists (fun t -> Tile.compare t tile = 0 && t != tile) hand_tiles
+  in
+  not related
+
+(** 牌の枚数をカウント *)
+let count_tile tile tiles =
+  List.length (List.filter (fun t -> Tile.compare t tile = 0) tiles)
+
+(** 数牌の端度（1,9に近いほど高い） *)
+let edge_penalty = function
+  | Tile.Suhai (_, n) ->
+    if n = 1 || n = 9 then 3
+    else if n = 2 || n = 8 then 1
+    else 0
+  | Tile.Jihai _ -> 2
+
+(** 牌の価値を評価（低いほど捨てやすい） *)
+let evaluate_tile tile hand_tiles =
+  let count = count_tile tile hand_tiles in
+  let isolated = is_isolated tile hand_tiles in
+  let edge = edge_penalty tile in
+
+  (* 基本スコア: 対子・刻子は価値が高い *)
+  let pair_bonus = match count with
+    | 1 -> 0
+    | 2 -> 30   (* 対子 *)
+    | 3 -> 50   (* 刻子 *)
+    | _ -> 60   (* 槓子候補 *)
+  in
+
+  (* 連続性: 順子に使える数牌は価値が高い *)
+  let sequence_bonus = match tile with
+    | Tile.Suhai (suit, n) ->
+      let has num =
+        num >= 1 && num <= 9 &&
+        List.exists (fun t -> Tile.compare t (Tile.Suhai (suit, num)) = 0) hand_tiles
+      in
+      let bonus = ref 0 in
+      (* 両面搭子 *)
+      if has (n - 1) && has (n + 1) then bonus := !bonus + 40;
+      (* 連続搭子 *)
+      if has (n - 1) then bonus := !bonus + 15;
+      if has (n + 1) then bonus := !bonus + 15;
+      (* 嵌張搭子 *)
+      if has (n - 2) then bonus := !bonus + 8;
+      if has (n + 2) then bonus := !bonus + 8;
+      (* 3連続 *)
+      if has (n - 1) && has (n - 2) then bonus := !bonus + 20;
+      if has (n + 1) && has (n + 2) then bonus := !bonus + 20;
+      !bonus
+    | Tile.Jihai _ -> 0
+  in
+
+  (* 孤立牌ペナルティ *)
+  let isolation_penalty = if isolated then -20 else 0 in
+
+  pair_bonus + sequence_bonus + isolation_penalty - edge
+
+(** 捨て牌を選択する（最も価値の低い牌を捨てる） *)
+let choose_discard (hand_tiles : Tile.tile list) : Tile.tile =
+  (* 各牌のユニークリスト *)
+  let unique_tiles =
+    let rec aux seen = function
+      | [] -> List.rev seen
+      | t :: rest ->
+        if List.exists (fun s -> Tile.compare s t = 0) seen then aux seen rest
+        else aux (t :: seen) rest
+    in
+    aux [] hand_tiles
+  in
+
+  match unique_tiles with
+  | [] -> List.hd hand_tiles  (* あり得ないが安全のため *)
+  | _ ->
+    let scored = List.map (fun t -> (t, evaluate_tile t hand_tiles)) unique_tiles in
+    let sorted = List.sort (fun (_, s1) (_, s2) -> compare s1 s2) scored in
+    fst (List.hd sorted)
+
+(** リーチ判定: テンパイ + 門前 + 持ち点1000以上 *)
+let should_riichi (player : Player.t) : bool =
+  if player.is_riichi then false
+  else if not (Player.is_menzen player) then false
+  else if player.score < 1000 then false
+  else
+    (* 13枚でテンパイしているか確認 *)
+    let hand_13 = match player.hand.tsumo with
+      | Some tsumo_tile ->
+        (match Mentsu.remove_one tsumo_tile player.hand.tiles with
+         | Some rest -> rest
+         | None -> player.hand.tiles)
+      | None -> player.hand.tiles
+    in
+    if List.length hand_13 = 13 then
+      Hand.tenpai_tiles (Hand.make hand_13) <> []
+    else
+      false
+
+(** CPUの行動を決定 *)
+type action =
+  | Discard of Tile.tile
+  | DeclareRiichi of Tile.tile  (** リーチ宣言 + 捨て牌 *)
+  | TsumoAgari                  (** ツモ和了 *)
+
+let decide (player : Player.t) (bakaze : Tile.jihai) : action =
+  (* ツモ和了チェック *)
+  let ctx = {
+    Yaku.is_tsumo = true;
+    is_riichi = player.is_riichi;
+    is_ippatsu = player.is_ippatsu;
+    is_tenhou = false;
+    is_chiihou = false;
+    bakaze;
+    jikaze = player.jikaze;
+  } in
+  let is_oya = player.jikaze = Tile.Ton in
+  match Scoring.score_hand player.hand.tiles ctx is_oya with
+  | Some _ -> TsumoAgari
+  | None ->
+    let tile = choose_discard player.hand.tiles in
+    (* リーチ判定 *)
+    if should_riichi player then
+      DeclareRiichi tile
+    else
+      Discard tile

--- a/src/mahjong-bridge.ts
+++ b/src/mahjong-bridge.ts
@@ -116,6 +116,17 @@ export function nextRound(oyaWon: boolean): GameState | null {
   return parse<GameState>(mahjongJs.next_round(oyaWon));
 }
 
+// === AI ===
+
+export interface AiAction {
+  action: 'tsumo' | 'discard' | 'riichi';
+  tile?: Tile;
+}
+
+export function aiDecide(seat: number): AiAction | null {
+  return parse<AiAction>(mahjongJs.ai_decide(seat));
+}
+
 // === ユーティリティ ===
 
 /** 風の日本語名 */

--- a/test/test_mahjong.ml
+++ b/test/test_mahjong.ml
@@ -313,6 +313,43 @@ let test_jikaze_assignment _ =
   assert_equal Tile.Pei (Game.jikaze_of_seat 2 0);
   assert_equal Tile.Ton (Game.jikaze_of_seat 2 1)
 
+(* === AI tests === *)
+
+let test_ai_discard _ =
+  (* AI が手牌から牌を選択して返すことを確認 *)
+  let hand = Hand.make [m 1; m 2; m 3; p 5; p 6; p 7; s 1; s 3; s 5;
+                         s 7; s 9; ton; haku; hatsu] in
+  let player = { (Player.create Tile.Ton) with hand } in
+  let action = Ai.decide player Tile.Ton in
+  match action with
+  | Ai.Discard tile ->
+    assert_bool "discarded tile should be in hand"
+      (List.exists (fun t -> Tile.compare t tile = 0) hand.tiles)
+  | Ai.TsumoAgari -> () (* 万が一和了ならOK *)
+  | Ai.DeclareRiichi tile ->
+    assert_bool "riichi tile should be in hand"
+      (List.exists (fun t -> Tile.compare t tile = 0) hand.tiles)
+
+let test_ai_prefers_isolated _ =
+  (* 孤立牌を優先的に捨てる *)
+  let hand_tiles = [m 1; m 2; m 3; p 4; p 5; p 6; s 7; s 8; s 9;
+                     m 5; m 5; m 5; ton; haku] in
+  let discard = Ai.choose_discard hand_tiles in
+  (* ton か haku が孤立牌として選ばれるはず *)
+  let is_jihai = match discard with Tile.Jihai _ -> true | _ -> false in
+  assert_bool "should discard isolated jihai" is_jihai
+
+let test_ai_tsumo_agari _ =
+  (* ツモ和了可能な手ではツモ和了を選択 *)
+  let tiles = [m 1; m 2; m 3; m 4; m 5; m 6; m 7; m 8; m 9;
+               p 1; p 2; p 3; s 5; s 5] in
+  let hand = { Hand.tiles = List.sort Tile.compare tiles; tsumo = Some (s 5) } in
+  let player = { (Player.create Tile.Ton) with hand } in
+  let action = Ai.decide player Tile.Ton in
+  match action with
+  | Ai.TsumoAgari -> ()
+  | _ -> assert_failure "should choose tsumo agari"
+
 (* === Test suite === *)
 
 let suite =
@@ -352,6 +389,9 @@ let suite =
     "game_draw_and_discard" >:: test_game_draw_and_discard;
     "game_advance_turn" >:: test_game_advance_turn;
     "jikaze_assignment" >:: test_jikaze_assignment;
+    "ai_discard" >:: test_ai_discard;
+    "ai_prefers_isolated" >:: test_ai_prefers_isolated;
+    "ai_tsumo_agari" >:: test_ai_tsumo_agari;
   ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary
- `ai.ml`: CPU思考ロジック
  - 牌の価値評価: 対子/刻子ボーナス、順子候補の連続性評価、孤立牌検出、端牌ペナルティ
  - 最も価値の低い牌を選択して捨てる戦略
  - ツモ和了の自動判定
  - リーチ判定（テンパイ＋門前＋持ち点1000以上）
- Melange JS APIに`ai_decide`追加
- フロントエンドのCPU打牌をAIロジックに差し替え
- テスト3ケース追加（全38テスト通過）

## Test plan
- [x] `docker compose run --rm ocaml dune test` 全38テスト通過
- [x] `npx vite build` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)