### PR TITLE
Add README.md and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+.PHONY: setup build test dev clean ocaml-build ocaml-test ocaml-watch melange-copy docker-build
+
+# === セットアップ ===
+
+setup: docker-build npm-install melange-copy ## 初回セットアップ（Docker + npm + Melange出力コピー）
+
+docker-build: ## Dockerイメージをビルド
+	docker compose build
+
+npm-install: ## npm依存関係をインストール
+	npm install
+
+# === OCaml (Docker) ===
+
+ocaml-build: ## OCamlソースをビルド
+	docker compose run --rm ocaml dune build
+
+ocaml-test: ## OCamlテストを実行
+	docker compose run --rm ocaml dune test
+
+ocaml-watch: ## OCamlソースをウォッチビルド
+	docker compose up
+
+ocaml-shell: ## OCamlコンテナにシェルで入る
+	docker compose run --rm ocaml bash
+
+# === Melange ===
+
+melange-copy: ## MelangeのJS出力をsrc/generatedにコピー
+	bash scripts/copy-melange-output.sh
+
+# === フロントエンド ===
+
+dev: ## 開発サーバーを起動
+	npm run dev
+
+build: ocaml-build melange-copy ## プロダクションビルド（OCaml + フロント）
+	npm run build
+
+# === テスト ===
+
+test: ocaml-test ## 全テストを実行
+
+# === クリーンアップ ===
+
+clean: ## ビルド成果物を削除
+	rm -rf dist _build src/generated node_modules/.vite
+
+# === ヘルプ ===
+
+help: ## コマンド一覧を表示
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# 麻雀 - 日本式リーチ麻雀
+
+日本式リーチ麻雀のWebアプリケーション。麻雀のコアロジック（牌・面子・役判定・点数計算）をOCamlで実装し、MelangeでJavaScriptにコンパイルしてReactフロントエンドから利用しています。
+
+## 必要な環境
+
+- Docker
+- Node.js (v18+)
+- npm
+
+## セットアップ
+
+```bash
+# 初回セットアップ（Dockerイメージビルド + npm install + Melange出力コピー）
+make setup
+```
+
+## 起動方法
+
+```bash
+# 開発サーバーを起動（http://localhost:5173）
+make dev
+```
+
+OCamlのソースを変更した場合は、Melange出力の再コピーが必要です：
+
+```bash
+make melange-copy
+```
+
+## コマンド一覧
+
+```bash
+make help              # コマンド一覧を表示
+make setup             # 初回セットアップ
+make dev               # 開発サーバー起動
+make build             # プロダクションビルド
+make test              # テスト実行
+make ocaml-build       # OCamlビルド
+make ocaml-test        # OCamlテスト
+make ocaml-watch       # OCamlウォッチビルド
+make ocaml-shell       # OCamlコンテナにシェルで入る
+make melange-copy      # Melange JS出力をコピー
+make clean             # ビルド成果物を削除
+```
+
+## プロジェクト構成
+
+```
+src/
+  core/              # OCaml - 麻雀ロジック
+    tile.ml           # 牌の型定義
+    mentsu.ml         # 面子判定・和了パターン探索
+    hand.ml           # 手牌管理・テンパイ判定
+    yaku.ml           # 役判定
+    scoring.ml        # 符計算・点数計算
+    wall.ml           # 牌山・ドラ
+    player.ml         # プレイヤー状態・副露
+    game.ml           # 局進行管理
+    ai.ml             # CPU思考ロジック
+  bindings/          # Melange - OCaml→JSバインディング
+    mahjong_js.ml     # JS向けAPI
+  components/        # React - UIコンポーネント
+    TileView.tsx      # 牌の表示
+    PlayerHand.tsx    # 手牌
+    Kawa.tsx          # 河（捨て牌）
+    GameInfo.tsx      # 局情報
+    GameBoard.tsx     # ゲームボード
+    AgariDialog.tsx   # 和了結果表示
+  mahjong-bridge.ts  # TypeScript型定義・APIラッパー
+test/
+  test_mahjong.ml    # OUnit2テスト
+scripts/
+  copy-melange-output.sh  # Melange出力コピー
+```
+
+## 技術スタック
+
+| レイヤー | 技術 |
+|---------|------|
+| 麻雀ロジック | OCaml (Melange) |
+| フロントエンド | React + TypeScript |
+| スタイリング | Tailwind CSS |
+| ビルド | Dune (OCaml) + Vite (フロント) |
+| テスト | OUnit2 |
+| OCaml環境 | Docker |


### PR DESCRIPTION
## Summary
- `README.md`: セットアップ手順、起動方法、コマンド一覧、プロジェクト構成、技術スタック
- `Makefile`: Docker/OCaml/Melange/フロントエンドの全コマンドをまとめたタスクランナー

## Test plan
- [x] `make help` でコマンド一覧が正しく表示される
- [x] `make test` でテスト実行成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)