### PR TITLE
Fix server startup, add stop commands and leave room

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -115,6 +115,9 @@ function handleMessage(ws: WebSocket, msg: { type: string; [key: string]: unknow
     case 'skip_call':
       handleSkipCall(ws);
       break;
+    case 'leave_room':
+      handleLeaveRoom(ws);
+      break;
     default:
       sendError(ws, `不明なメッセージタイプ: ${msg.type}`);
   }
@@ -281,6 +284,25 @@ function handleRon(ws: WebSocket): void {
       processAiTurns(room);
     }
   }, 3000);
+}
+
+function handleLeaveRoom(ws: WebSocket): void {
+  const room = getRoomBySocket(ws);
+  if (!room) return;
+
+  const player = room.players.find(p => p.ws === ws);
+  const name = player?.name ?? '';
+
+  removePlayer(ws);
+  sendJson(ws, { type: 'room_left' });
+
+  if (room.players.length > 0) {
+    broadcastPlayerList(room);
+    broadcastToRoom(room, () => JSON.stringify({
+      type: 'message',
+      text: `${name} が退出しました`,
+    }));
+  }
 }
 
 function handleSkipCall(_ws: WebSocket): void {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,7 @@ function MultiplayerApp() {
         onCreateRoom={mp.createRoom}
         onJoinRoom={mp.joinRoom}
         onStartGame={mp.startGame}
+        onLeaveRoom={mp.leaveRoom}
       />
     );
   }

--- a/src/components/Lobby.tsx
+++ b/src/components/Lobby.tsx
@@ -11,6 +11,7 @@ interface LobbyProps {
   onCreateRoom: (name: string) => void;
   onJoinRoom: (roomId: string, name: string) => void;
   onStartGame: () => void;
+  onLeaveRoom: () => void;
 }
 
 export function Lobby({
@@ -22,6 +23,7 @@ export function Lobby({
   onCreateRoom,
   onJoinRoom,
   onStartGame,
+  onLeaveRoom,
 }: LobbyProps) {
   const [playerName, setPlayerName] = useState('');
   const [joinRoomId, setJoinRoomId] = useState('');
@@ -94,6 +96,13 @@ export function Lobby({
         {!isHost && (
           <p className="text-green-300">ホストがゲームを開始するのを待っています...</p>
         )}
+
+        <button
+          onClick={onLeaveRoom}
+          className="text-green-400 hover:text-red-400 text-sm transition"
+        >
+          ルームを退出する
+        </button>
 
         {error && <p className="text-red-400">{error}</p>}
       </div>

--- a/src/hooks/useMultiplayer.ts
+++ b/src/hooks/useMultiplayer.ts
@@ -156,6 +156,22 @@ export function useMultiplayer() {
     setState(s => ({ ...s, agariResult: null }));
   }, []);
 
+  const leaveRoom = useCallback(() => {
+    send({ type: 'leave_room' });
+    setState(s => ({
+      ...s,
+      roomId: null,
+      seat: -1,
+      players: [],
+      gameState: null,
+      agariResult: null,
+      turnInfo: null,
+      messages: [],
+      error: null,
+      gameEnd: null,
+    }));
+  }, [send]);
+
   return {
     ...state,
     createRoom,
@@ -165,5 +181,6 @@ export function useMultiplayer() {
     tsumo,
     riichi,
     clearAgari,
+    leaveRoom,
   };
 }


### PR DESCRIPTION
## Summary
PR #10 マージ後の追加修正:

- **サーバー起動修正**: tsx → `node --experimental-strip-types` に変更（Melange ESM互換性）
- **Makefile停止コマンド**: `make stop` / `make stop-docker` / `make stop-server` / `make stop-dev`
- **ルーム退出機能**: 待機画面に退出ボタン追加、サーバー側のleave_room処理

## Test plan
- [x] `make server-dev` でサーバー起動成功
- [x] `npx vite build` ビルド成功
- [x] 全38テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)