### PR TITLE
Online multiplayer fixes: server startup, stop commands, room leave

### DIFF
--- a/src/hooks/useMultiplayer.ts
+++ b/src/hooks/useMultiplayer.ts
@@ -109,6 +109,20 @@ export function useMultiplayer() {
       case 'error':
         setState(s => ({ ...s, error: msg.message }));
         break;
+      case 'room_left':
+        setState(s => ({
+          ...s,
+          roomId: null,
+          seat: -1,
+          players: [],
+          gameState: null,
+          agariResult: null,
+          turnInfo: null,
+          messages: [],
+          error: null,
+          gameEnd: null,
+        }));
+        break;
       case 'can_ron':
         // TODO: ロン選択UIの表示
         break;
@@ -158,18 +172,7 @@ export function useMultiplayer() {
 
   const leaveRoom = useCallback(() => {
     send({ type: 'leave_room' });
-    setState(s => ({
-      ...s,
-      roomId: null,
-      seat: -1,
-      players: [],
-      gameState: null,
-      agariResult: null,
-      turnInfo: null,
-      messages: [],
-      error: null,
-      gameEnd: null,
-    }));
+    // サーバーからroom_leftが返ってきた時にhandleMessageで状態リセットされる
   }, [send]);
 
   return {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -27,6 +27,7 @@ export interface PlayerInfo {
 export type ServerMessage =
   | { type: 'room_created'; roomId: string; seat: number }
   | { type: 'room_joined'; roomId: string; seat: number }
+  | { type: 'room_left' }
   | { type: 'player_list'; players: PlayerInfo[] }
   | { type: 'game_state'; state: GameState }
   | { type: 'your_turn'; canTsumo: boolean; canRiichi: boolean; tenpaiTiles: Tile[] }


### PR DESCRIPTION
## Summary
- サーバー起動修正: tsx → `node --experimental-strip-types`（Melange ESM互換性）
- Makefile停止コマンド: `make stop` / `make stop-docker` / `make stop-server` / `make stop-dev`
- ルーム退出機能: 待機画面に退出ボタン、サーバー側leave_room処理
- 退出バグ修正: room_leftメッセージのハンドリング追加

## Test plan
- [x] サーバー起動成功
- [x] ルーム退出が正常に動作
- [x] フロントエンドビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)