### PR TITLE
Online multiplayer, UI overhaul, full rule implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,61 +1,98 @@
 # CLAUDE.md - 麻雀プロジェクト
 
 ## プロジェクト概要
-日本式麻雀（リーチ麻雀）のWebアプリケーション。
+日本式麻雀（リーチ麻雀）のWebアプリケーション。一人プレイ（CPU対戦）とオンライン対戦に対応。
 
 ## 技術スタック
 - **麻雀ロジック**: OCaml（Melange経由でJSにコンパイル）
 - **フロントエンド**: React + TypeScript
-- **スタイリング**: Tailwind CSS
+- **サーバー**: Node.js + WebSocket (ws)
+- **スタイリング**: Tailwind CSS + インラインスタイル
 - **ビルドツール**: Dune (OCaml) + Vite (フロント)
-- **テスト**: OUnit2 (OCamlロジック) / Vitest (UI)
+- **テスト**: OUnit2 (OCamlロジック)
 - **パッケージ管理**: opam (OCaml) + npm (JS)
 - **OCaml環境**: Docker（開発環境をコンテナで管理）
 
 ## ブランチ戦略
-- 機能単位で細かくブランチを切り分け、PRを作成する
-- **新しいブランチは常に現在の作業ブランチから切る**（mainからではない）
-  - 例: `feature/tile-types` → `feature/hand-evaluation` → `feature/scoring` のように連鎖的に派生させる
+- **機能単位で細かくブランチを切り分け、PRを作成する**
+- 新しいブランチは常に現在の作業ブランチから切る（mainからではない）
+  - 例: `feature/tile-types` → `feature/hand-evaluation` → `feature/scoring`
 - ブランチ名は `feature/<機能名>` の形式にする
 - PRのマージ先は直前の親ブランチとする
 - 各PRは小さく、レビューしやすい単位に保つ
+- **1つの機能追加やバグ修正に対して1つのPRを立てる**
 
 ## コーディング規約
 - 麻雀のコアロジック（牌の定義、手牌補完、役判定、点数計算）はすべてOCamlで実装する
 - OCaml側では代数的データ型とパターンマッチを活用し、牌・面子・役を型安全に表現する
 - UIはReact + TypeScriptで実装し、Melange経由でOCamlロジックを呼び出す
 - 麻雀用語は英語表記を使用する（例: `hai`, `mentsu`, `agari`, `tsumo`）
+- OCamlの日本語文字列はMelangeで文字化けするため、日本語表示はTypeScript側で定義する
 
-## ディレクトリ構成（予定）
+## ディレクトリ構成
 ```
 src/
   core/              # OCaml - 麻雀ロジック（UI非依存）
     tile.ml           # 牌の型定義
-    hand.ml           # 手牌管理・補完
-    mentsu.ml         # 面子判定
+    hand.ml           # 手牌管理・テンパイ判定
+    mentsu.ml         # 面子判定・和了パターン探索
     yaku.ml           # 役判定
-    scoring.ml        # 点数計算
-    game.ml           # ゲーム進行管理
+    scoring.ml        # 符計算・点数計算
+    wall.ml           # 牌山・ドラ・赤ドラ
+    player.ml         # プレイヤー状態・副露（ポン・チー・カン）
+    game.ml           # ゲーム進行管理・流局精算
     ai.ml             # CPU思考ロジック
-  frontend/          # React + TypeScript - UI
-    components/       # UIコンポーネント
-    hooks/            # カスタムフック
-    assets/           # 牌画像・音声等
-    App.tsx
-    main.tsx
+  bindings/          # Melange - OCaml→JSバインディング
+    mahjong_js.ml     # クライアント用API
+    mahjong_server_js.ml  # サーバー用API（マルチルーム対応）
+  components/        # React - UIコンポーネント
+    TileView.tsx      # 牌の表示（SVG描画・赤ドラ対応）
+    PlayerHand.tsx    # 手牌（ツモ牌分離・副露表示）
+    Kawa.tsx          # 河（捨て牌・6列グリッド）
+    CenterPanel.tsx   # 中央スコアパネル
+    DoraDisplay.tsx   # ドラ表示牌
+    GameBoard.tsx     # シングルプレイ用ゲームボード
+    MultiplayerGameBoard.tsx  # マルチプレイ用ゲームボード
+    Lobby.tsx         # ルーム作成/参加UI
+    AgariDialog.tsx   # 和了結果表示（手牌・ドラ・裏ドラ）
+    ScoreTransition.tsx  # 点数移動表示
+  hooks/
+    useMultiplayer.ts # WebSocket通信フック
+  protocol.ts        # WebSocketメッセージ型定義
+  mahjong-bridge.ts  # TypeScript型定義・APIラッパー・役名マッピング
+server/
+  src/
+    index.ts          # WebSocketサーバーエントリポイント
+    room-manager.ts   # ルーム管理（座席シャッフル・ゲームモード）
+    game-controller.ts # ゲーム進行管理
+test/
+  test_mahjong.ml    # OUnit2テスト
+scripts/
+  copy-melange-output.sh  # Melange出力コピー＋パッチ
 ```
 
 ## Docker環境
 - OCamlのビルド・テストはDocker内で実行する
-- `docker compose` でOCaml環境とフロント開発環境を管理
+- `docker compose` でOCaml環境を管理
 
-## コマンド
+## コマンド（Makefile）
 ```bash
-docker compose up -d          # OCaml開発コンテナ起動
-docker compose exec ocaml dune build   # OCamlビルド
-docker compose exec ocaml dune test    # OCamlテスト実行
-npm install                  # JS依存関係インストール
-npm dev                      # 開発サーバー起動
-npm build                    # プロダクションビルド
-npm test                     # UIテスト実行
+make help              # コマンド一覧を表示
+make setup             # 初回セットアップ（Docker + npm + サーバー + Melange）
+make dev               # フロントエンド開発サーバー起動
+make server-dev        # WebSocketサーバー起動（開発モード）
+make build             # プロダクションビルド（OCaml + フロント）
+make test              # OCamlテスト実行
+make ocaml-build       # OCamlビルド
+make ocaml-test        # OCamlテスト
+make melange-copy      # Melange JS出力をコピー
+make stop              # 全サービス停止
+make stop-server       # WebSocketサーバー停止
+make stop-dev          # フロント開発サーバー停止
+make clean             # ビルド成果物削除 + 全停止
 ```
+
+## 注意事項
+- Melange出力の`string.js`はVite/Rolldownとの互換性問題があるため、`copy-melange-output.sh`でパッチを適用している
+- サーバーは`node --experimental-strip-types`で実行する（tsxはMelange ESMと互換性がない）
+- OCaml変更後は必ず`make melange-copy`を実行してJS出力を更新する


### PR DESCRIPTION
## Summary

大規模な機能追加・バグ修正をまとめたPR。今後は1機能1PRを徹底。

### オンラインマルチプレイ
- WebSocketサーバー（Node.js + ws）
- ルーム作成/参加（6文字ID）、退出機能
- 座席ランダムシャッフル
- 東風戦/半荘戦の選択

### UI
- 牌デザイン刷新（SVG筒子/索子、明朝体漢字、赤ドラ表示）
- 卓を囲むレイアウト（左右縦並び、捨て牌6列グリッド中央配置）
- ツモ牌の右端分離表示、副露表示
- ドラ表示牌（左上）、和了時の手牌/ドラ/裏ドラ表示
- 点数移動表示（流局/和了後）
- チー候補の牌選択UI

### 鳴き
- ポン・チー・明槓・暗槓・加槓
- ロン/ツモのスキップ選択

### ルール準拠
- ドラ/裏ドラ/赤ドラの点数加算
- 食い下がり（鳴き時の翻数減少）
- 振聴（フリテン）
- 流局時テンパイ/ノーテン精算
- 親の連荘（和了/テンパイ時）
- 海底/河底、4カン流局
- 副露対応の和了判定（find_agari_patterns_furo）
- リーチ判定（14枚手牌対応）
- 配牌ランダム化（Random.self_init）
- 席順ランダム化（seat_offset永続化）

### その他
- CLAUDE.md更新
- Melange/Vite互換性修正

## Test plan
- [x] 全38テスト通過
- [x] フロントエンドビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)