### PR TITLE
Add haitei/houtei as proper yaku types

### DIFF
--- a/src/bindings/mahjong_js.ml
+++ b/src/bindings/mahjong_js.ml
@@ -52,7 +52,8 @@ let yaku_id_of (y : Yaku.yaku) : string =
   | Yaku.Daisangen -> "daisangen" | Yaku.Shousuushii -> "shousuushii"
   | Yaku.Daisuushii -> "daisuushii" | Yaku.Tsuuiisou -> "tsuuiisou"
   | Yaku.Ryuuiisou -> "ryuuiisou" | Yaku.Chinroutou -> "chinroutou"
-  | Yaku.Chuuren -> "chuuren" | Yaku.Tenhou -> "tenhou" | Yaku.Chiihou -> "chiihou"
+  | Yaku.Chuuren -> "chuuren" | Yaku.Haitei -> "haitei" | Yaku.Houtei -> "houtei"
+  | Yaku.Tenhou -> "tenhou" | Yaku.Chiihou -> "chiihou"
 
 let yaku_to_json (y : Yaku.yaku) : string =
   json_obj [("id", json_str (yaku_id_of y)); ("han", json_int (Yaku.han_of_yaku y))]

--- a/src/bindings/mahjong_server_js.ml
+++ b/src/bindings/mahjong_server_js.ml
@@ -50,7 +50,8 @@ let yaku_id_of (y : Yaku.yaku) : string =
   | Yaku.Daisangen -> "daisangen" | Yaku.Shousuushii -> "shousuushii"
   | Yaku.Daisuushii -> "daisuushii" | Yaku.Tsuuiisou -> "tsuuiisou"
   | Yaku.Ryuuiisou -> "ryuuiisou" | Yaku.Chinroutou -> "chinroutou"
-  | Yaku.Chuuren -> "chuuren" | Yaku.Tenhou -> "tenhou" | Yaku.Chiihou -> "chiihou"
+  | Yaku.Chuuren -> "chuuren" | Yaku.Haitei -> "haitei" | Yaku.Houtei -> "houtei"
+  | Yaku.Tenhou -> "tenhou" | Yaku.Chiihou -> "chiihou"
 
 let yaku_to_json (y : Yaku.yaku) : string =
   json_obj [("id", json_str (yaku_id_of y)); ("han", json_int (Yaku.han_of_yaku y))]

--- a/src/core/yaku.ml
+++ b/src/core/yaku.ml
@@ -30,6 +30,8 @@ type yaku =
   | Ryuuiisou          (** 緑一色 *)
   | Chinroutou         (** 清老頭 *)
   | Chuuren            (** 九蓮宝燈 *)
+  | Haitei             (** 海底摸月 *)
+  | Houtei             (** 河底撈魚 *)
   | Tenhou             (** 天和 *)
   | Chiihou            (** 地和 *)
 
@@ -42,6 +44,8 @@ let han_of_yaku = function
   | Pinfu -> 1
   | Iipeiko -> 1
   | Yakuhai _ -> 1
+  | Haitei -> 1
+  | Houtei -> 1
   | Chanta -> 2
   | Ittsu -> 2
   | Sanshoku_doujun -> 2
@@ -97,6 +101,8 @@ let name_of_yaku = function
   | Ryuuiisou -> "緑一色"
   | Chinroutou -> "清老頭"
   | Chuuren -> "九蓮宝燈"
+  | Haitei -> "海底摸月"
+  | Houtei -> "河底撈魚"
   | Tenhou -> "天和"
   | Chiihou -> "地和"
 
@@ -506,8 +512,8 @@ let judge_yaku ?(furo_count=0) (pattern : Mentsu.agari_pattern) (ctx : agari_con
     if ctx.is_tsumo && ctx.is_menzen then add Tsumo;
     if ctx.is_tenhou then add Tenhou;
     if ctx.is_chiihou then add Chiihou;
-    if ctx.is_haitei then add Tsumo;  (* 海底ツモ: 1翻追加 *)
-    if ctx.is_houtei then add Tsumo;  (* 河底ロン: 1翻追加 *)
+    if ctx.is_haitei then add Haitei;
+    if ctx.is_houtei then add Houtei;
 
     (* 手役: 門前限定の役は鳴いていたら付かない *)
     if check_tanyao pattern then add Tanyao;

--- a/src/mahjong-bridge.ts
+++ b/src/mahjong-bridge.ts
@@ -62,7 +62,8 @@ const yakuNames: Record<string, string> = {
   chinitsu: '清一色', kokushi: '国士無双', suuankou: '四暗刻',
   daisangen: '大三元', shousuushii: '小四喜', daisuushii: '大四喜',
   tsuuiisou: '字一色', ryuuiisou: '緑一色', chinroutou: '清老頭',
-  chuuren: '九蓮宝燈', tenhou: '天和', chiihou: '地和',
+  chuuren: '九蓮宝燈', haitei: '海底摸月', houtei: '河底撈魚',
+  tenhou: '天和', chiihou: '地和',
 };
 
 export function yakuName(id: string): string {


### PR DESCRIPTION
海底摸月/河底撈魚を独立した役として追加（以前はTsumoで代用）
🤖 Generated with [Claude Code](https://claude.com/claude-code)