### PR TITLE
Fix tenhou/chiihou detection and suuankou ron wait type

### DIFF
--- a/src/bindings/mahjong_js.ml
+++ b/src/bindings/mahjong_js.ml
@@ -202,7 +202,7 @@ let check_tsumo () : string =
     let ctx = {
       Yaku.is_tsumo = true; is_riichi = player.is_riichi; is_double_riichi = player.is_double_riichi;
       is_ippatsu = false; is_tenhou = false; is_chiihou = false; is_menzen = Player.is_menzen player; is_haitei = false; is_houtei = false; dora_count = dora_n + uradora_n + aka_n;
-      bakaze = game.bakaze; jikaze = player.jikaze;
+      agari_tile = None; bakaze = game.bakaze; jikaze = player.jikaze;
     } in
     let is_oya = player.jikaze = Tile.Ton in
     let furo_count = List.length player.furo_list in
@@ -263,7 +263,7 @@ let can_ron seat : bool =
           Yaku.is_tsumo = false; is_riichi = player.is_riichi; is_double_riichi = player.is_double_riichi;
           is_ippatsu = false; is_tenhou = false; is_chiihou = false;
           is_menzen = Player.is_menzen player; is_haitei = false; is_houtei = false;
-          dora_count = 0; bakaze = game.bakaze; jikaze = player.jikaze;
+          dora_count = 0; agari_tile = None; bakaze = game.bakaze; jikaze = player.jikaze;
         } in
         let is_oya = player.jikaze = Tile.Ton in
         match Scoring.score_hand ~furo_count:(List.length player.furo_list) ~furo_mentsu:player.furo_list tiles ctx is_oya with
@@ -285,7 +285,7 @@ let check_ron seat : string =
       let ctx = {
         Yaku.is_tsumo = false; is_riichi = player.is_riichi; is_double_riichi = player.is_double_riichi;
         is_ippatsu = false; is_tenhou = false; is_chiihou = false; is_menzen = Player.is_menzen player; is_haitei = false; is_houtei = false; dora_count = dora_n + uradora_n + aka_n;
-        bakaze = game.bakaze; jikaze = player.jikaze;
+        agari_tile = None; bakaze = game.bakaze; jikaze = player.jikaze;
       } in
       let is_oya = player.jikaze = Tile.Ton in
       (match Scoring.score_hand ~furo_count:(List.length player.furo_list) ~furo_mentsu:player.furo_list tiles ctx is_oya with

--- a/src/bindings/mahjong_server_js.ml
+++ b/src/bindings/mahjong_server_js.ml
@@ -254,7 +254,7 @@ let check_tsumo room_id : string =
     let ctx = {
       Yaku.is_tsumo = true; is_riichi = player.is_riichi; is_double_riichi = player.is_double_riichi;
       is_ippatsu = false; is_tenhou = false; is_chiihou = false; is_menzen = Player.is_menzen player; is_haitei = false; is_houtei = false; dora_count = 0;
-      bakaze = game.bakaze; jikaze = player.jikaze;
+      agari_tile = None; bakaze = game.bakaze; jikaze = player.jikaze;
     } in
     let is_oya = player.jikaze = Tile.Ton in
     match Scoring.score_hand ~furo_count:(List.length player.furo_list) ~furo_mentsu:player.furo_list player.hand.tiles ctx is_oya with
@@ -286,7 +286,7 @@ let check_ron room_id seat : string =
       let ctx = {
         Yaku.is_tsumo = false; is_riichi = player.is_riichi; is_double_riichi = player.is_double_riichi;
         is_ippatsu = false; is_tenhou = false; is_chiihou = false; is_menzen = Player.is_menzen player; is_haitei = false; is_houtei = false; dora_count = 0;
-        bakaze = game.bakaze; jikaze = player.jikaze;
+        agari_tile = None; bakaze = game.bakaze; jikaze = player.jikaze;
       } in
       let is_oya = player.jikaze = Tile.Ton in
       (match Scoring.score_hand ~furo_count:(List.length player.furo_list) ~furo_mentsu:player.furo_list tiles ctx is_oya with

--- a/src/core/ai.ml
+++ b/src/core/ai.ml
@@ -129,6 +129,7 @@ let decide (player : Player.t) (bakaze : Tile.jihai) : action =
     is_haitei = false;
     is_houtei = false;
     dora_count = 0;
+    agari_tile = None;
     bakaze;
     jikaze = player.jikaze;
   } in

--- a/src/core/game.ml
+++ b/src/core/game.ml
@@ -203,6 +203,7 @@ let ron (game : round) (winner : int) : (round, string) result =
       is_haitei = false;
       is_houtei = is_haitei game;
       dora_count = total_dora;
+      agari_tile = Some tile;
       bakaze = game.bakaze;
       jikaze = player.jikaze;
     } in
@@ -226,17 +227,20 @@ let tsumo_agari (game : round) : (round, string) result =
   let dora_count = Wall.count_dora game.wall game.kan_count player.hand.tiles in
   let uradora_count = if player.is_riichi then Wall.count_uradora game.wall game.kan_count player.hand.tiles else 0 in
   let total_dora = dora_count + uradora_count + player.aka_count in
+  let is_first = game.first_turns.(game.current_turn) && game.no_calls_yet in
+  let is_oya_player = player.jikaze = Tile.Ton in
   let ctx = {
     Yaku.is_tsumo = true;
     is_riichi = player.is_riichi;
     is_double_riichi = player.is_double_riichi;
     is_ippatsu = player.is_ippatsu;
-    is_tenhou = false;
-    is_chiihou = false;
+    is_tenhou = is_first && is_oya_player;
+    is_chiihou = is_first && not is_oya_player;
     is_menzen = Player.is_menzen player;
     is_haitei = is_haitei game;
     is_houtei = false;
     dora_count = total_dora;
+    agari_tile = player.hand.tsumo;
     bakaze = game.bakaze;
     jikaze = player.jikaze;
   } in

--- a/src/core/yaku.ml
+++ b/src/core/yaku.ml
@@ -159,6 +159,7 @@ type agari_context = {
   is_haitei : bool;       (** 海底ツモか *)
   is_houtei : bool;       (** 河底ロンか *)
   dora_count : int;       (** ドラ枚数 *)
+  agari_tile : Tile.tile option;  (** 和了牌（ロン時の牌、ツモ時はツモ牌） *)
   bakaze : Tile.jihai;    (** 場風 *)
   jikaze : Tile.jihai;    (** 自風 *)
 }
@@ -174,6 +175,7 @@ let default_context = {
   is_haitei = false;
   is_houtei = false;
   dora_count = 0;
+  agari_tile = None;
   bakaze = Tile.Ton;
   jikaze = Tile.Ton;
 }
@@ -244,13 +246,17 @@ let check_sanankou ?(furo_count=0) (pattern : Mentsu.agari_pattern) : bool =
   ) hand_mentsu) in
   ankou_count >= 3
 
-(** 四暗刻判定: 暗刻が4つ（全て手牌から） *)
-let check_suuankou ?(furo_count=0) (pattern : Mentsu.agari_pattern) : bool =
-  if furo_count > 0 then false  (* 副露ありなら四暗刻不可 *)
+(** 四暗刻判定: 暗刻が4つ（全て手牌から）
+    ロン時は単騎待ち（雀頭待ち）の場合のみ成立 *)
+let check_suuankou ?(furo_count=0) (pattern : Mentsu.agari_pattern) (ctx : agari_context) : bool =
+  if furo_count > 0 then false
+  else if not (List.for_all is_koutsu_or_kantsu pattern.mentsu_list) then false
+  else if ctx.is_tsumo then true  (* ツモなら常にOK *)
   else
-    List.for_all (fun m ->
-      is_koutsu_or_kantsu m
-    ) pattern.mentsu_list
+    (* ロン: 和了牌が雀頭の一部（単騎待ち）の場合のみ *)
+    match ctx.agari_tile with
+    | Some t -> Tile.compare t pattern.jantai = 0
+    | None -> false
 
 (** 一盃口判定: 同じ順子が2組 *)
 let check_iipeiko (pattern : Mentsu.agari_pattern) : bool =
@@ -494,7 +500,7 @@ let judge_yaku ?(furo_count=0) (pattern : Mentsu.agari_pattern) (ctx : agari_con
 
   (* 役満チェック *)
   (* 四暗刻: ツモなら常にOK、ロンは単騎待ちの場合のみ（furo_count=0前提） *)
-  if check_suuankou ~furo_count pattern then add Suuankou;
+  if check_suuankou ~furo_count pattern ctx then add Suuankou;
   if check_daisangen pattern then add Daisangen;
   if check_shousuushii pattern then add Shousuushii;
   if check_daisuushii pattern then add Daisuushii;


### PR DESCRIPTION
## Summary
- 天和: 親の最初のツモで和了（配牌和了）を正しく判定
- 地和: 子の最初のツモで和了を正しく判定  
- 四暗刻ロン: 単騎待ち（雀頭待ち）の場合のみ成立するよう修正

## Test plan
- [x] 全38テスト通過
- [x] フロントエンドビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)