### PR TITLE
Fix pinfu tsumo fu calculation (20 fu fixed)

### DIFF
--- a/src/core/scoring.ml
+++ b/src/core/scoring.ml
@@ -100,8 +100,11 @@ let score_hand ?(furo_count=0) ?(furo_mentsu=[]) (tiles : Tile.tile list) (ctx :
   | None -> None
   | Some (yakus, han) ->
     let patterns = Mentsu.find_agari_patterns_furo tiles furo_count in
+    let has_pinfu = List.exists (fun y -> y = Yaku.Pinfu) yakus in
     let fu =
       if List.exists (fun y -> y = Yaku.Chiitoitsu) yakus then 25
+      else if has_pinfu && ctx.is_tsumo then 20  (* 平和ツモ: 20符固定 *)
+      else if has_pinfu && not ctx.is_tsumo then 30  (* 平和ロン: 30符固定 *)
       else
         match patterns with
         | [] -> 30


### PR DESCRIPTION
## Summary
平和+門前ツモの符計算を修正。

以前: base30 + tsumo2 = 32 → 40符（間違い）
修正後:
- 平和ツモ: 20符固定
- 平和ロン: 30符固定

リーチ棒の精算はレビューで指摘されましたが、確認の結果正しく動作しています
（リーチ棒は宣言時に既に差し引かれるテーブルプール）。

## Test plan
- [x] 全38テスト通過
- [x] フロントエンドビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)