### PR TITLE
Show wait tiles per discard during riichi declaration

### DIFF
--- a/src/bindings/mahjong_js.ml
+++ b/src/bindings/mahjong_js.ml
@@ -412,6 +412,33 @@ let riichi_discard_candidates seat : string =
       ) tiles;
       json_arr (List.rev !candidates)
 
+(** リーチ宣言時の各捨て牌候補に対する待ち牌リストを返す *)
+let riichi_discard_with_waits seat : string =
+  match !game_ref with
+  | None -> json_arr []
+  | Some game ->
+    let player = game.players.(seat) in
+    let tiles = player.hand.tiles in
+    if List.length tiles <> 14 then json_arr []
+    else
+      let tried = ref [] in
+      let results = ref [] in
+      List.iter (fun t ->
+        if not (List.exists (fun s -> Tile.compare s t = 0) !tried) then begin
+          tried := t :: !tried;
+          match Mentsu.remove_one t tiles with
+          | Some rest ->
+            let waits = Hand.tenpai_tiles (Hand.make rest) in
+            if waits <> [] then
+              results := json_obj [
+                ("discard", tile_to_json t);
+                ("waits", json_arr (List.map tile_to_json waits))
+              ] :: !results
+          | None -> ()
+        end
+      ) tiles;
+      json_arr (List.rev !results)
+
 let next_round oya_won was_agari : string =
   match !game_ref with
   | None -> json_null

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -6,8 +6,9 @@ import {
   declareRiichi, aiDecide, kazeToJa,
   canPon, doPon, canChi, doChi,
   canMinkan, doMinkan, canAnkan, doAnkan, canKakan, doKakan,
-  canDeclareRiichi, riichiDiscardCandidates,
+  canDeclareRiichi, riichiDiscardCandidates, riichiDiscardWithWaits,
   canKyuushu, declareKyuushu,
+  type RiichiDiscardOption,
 } from '../mahjong-bridge';
 import { PlayerHand } from './PlayerHand';
 import { Kawa } from './Kawa';
@@ -56,11 +57,14 @@ export function GameBoard({ onBack }: GameBoardProps) {
   }, []);
 
   const [riichiCandidates, setRiichiCandidates] = useState<Tile[]>([]);
+  const [riichiOptions, setRiichiOptions] = useState<RiichiDiscardOption[]>([]);
 
   const handleRiichi = useCallback(() => {
     const candidates = riichiDiscardCandidates(HUMAN_SEAT);
+    const options = riichiDiscardWithWaits(HUMAN_SEAT);
     setRiichiMode(true);
     setRiichiCandidates(candidates);
+    setRiichiOptions(options);
     setMessage('リーチ！ 捨てる牌を選んでください');
   }, []);
 
@@ -81,6 +85,7 @@ export function GameBoard({ onBack }: GameBoardProps) {
       if (riichiState) setState(riichiState);
       setRiichiMode(false);
       setRiichiCandidates([]);
+      setRiichiOptions([]);
     }
 
     const newState = discardTile(tile);
@@ -479,12 +484,48 @@ export function GameBoard({ onBack }: GameBoardProps) {
             disabledTiles={riichiMode ? riichiCandidates : undefined}
           />
         </div>
-        {tenpaiTiles.length > 0 && (
+        {/* リーチモード: 各候補の待ち牌を表示 */}
+        {riichiMode && riichiOptions.length > 0 ? (
+          <div style={{ marginTop: 6 }}>
+            {/* 選択中の牌の待ちをハイライト、未選択時は全候補表示 */}
+            {(() => {
+              const allHand = state.players[HUMAN_SEAT].hand ?? [];
+              const tsumo = state.players[HUMAN_SEAT].tsumo;
+              // 選択された牌を特定
+              let selectedDiscard: Tile | null = null;
+              if (selectedTile !== null) {
+                if (selectedTile < allHand.length) {
+                  selectedDiscard = allHand[selectedTile];
+                } else if (tsumo) {
+                  selectedDiscard = tsumo;
+                }
+              }
+              const filtered = selectedDiscard
+                ? riichiOptions.filter(o =>
+                    o.discard.kind === selectedDiscard!.kind &&
+                    o.discard.suit === selectedDiscard!.suit &&
+                    o.discard.number === selectedDiscard!.number
+                  )
+                : riichiOptions;
+              return (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+                  {filtered.map((opt, i) => (
+                    <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <TileView tile={opt.discard} small />
+                      <span style={{ fontSize: 11, color: '#888' }}>→ 待ち:</span>
+                      {opt.waits.map((w, j) => <TileView key={j} tile={w} small />)}
+                    </div>
+                  ))}
+                </div>
+              );
+            })()}
+          </div>
+        ) : tenpaiTiles.length > 0 ? (
           <div style={{ marginTop: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
             <span style={{ fontSize: 11, color: '#8a8' }}>待ち:</span>
             {tenpaiTiles.map((t, i) => <TileView key={i} tile={t} small />)}
           </div>
-        )}
+        ) : null}
         {/* アクションボタン */}
         <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginTop: 8 }}>
           {canTsumo && (

--- a/src/mahjong-bridge.ts
+++ b/src/mahjong-bridge.ts
@@ -164,6 +164,15 @@ export function declareKyuushu(): GameState | null {
   return parse<GameState>(mahjongJs.declare_kyuushu());
 }
 
+export interface RiichiDiscardOption {
+  discard: Tile;
+  waits: Tile[];
+}
+
+export function riichiDiscardWithWaits(seat: number): RiichiDiscardOption[] {
+  try { return JSON.parse(mahjongJs.riichi_discard_with_waits(seat)) as RiichiDiscardOption[]; } catch { return []; }
+}
+
 export function canDeclareRiichi(seat: number): boolean {
   return mahjongJs.can_declare_riichi(seat);
 }


### PR DESCRIPTION
## Summary
リーチ宣言時に「どの牌を捨てるとどの待ちになるか」を表示。

- 全候補: [捨て牌] → 待ち: [待ち牌1] [待ち牌2] ...
- 牌を選択すると、その牌の待ちのみハイライト表示
- 捨てられない牌は暗く表示（既存機能）

## Test plan
- [x] 全38テスト通過
- [x] フロントエンドビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)